### PR TITLE
chore: start-issue 워크트리 지원 및 스킬 모델 최적화

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -4,7 +4,7 @@ description: Review a pull request and provide feedback
 argument-hint: "[PR 번호]"
 disable-model-invocation: true
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
-model: sonnet
+model: opus
 ---
 
 # PR 리뷰

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -3,7 +3,7 @@ name: start-issue
 description: Pick a ready issue, create a branch, and update issue status
 disable-model-invocation: true
 allowed-tools: Bash, Read, AskUserQuestion
-model: sonnet
+model: haiku
 ---
 
 # 이슈 작업 시작
@@ -41,11 +41,14 @@ model: sonnet
 - 예: "CI 워크플로우에 캐싱 추가하기" (이슈 #18) → `feat/ci-caching-18`
 - **필수**: AskUserQuestion으로 생성된 브랜치명을 제시하고 수정 기회를 제공한다
 
-### 4. 브랜치 생성 및 checkout
+### 4. 워크트리 생성 및 이동
 ```bash
 git checkout main && git pull
-git checkout -b <브랜치명>
+git worktree add .claude/worktrees/<브랜치명> -b <브랜치명>
+cd .claude/worktrees/<브랜치명>
 ```
+- `.claude/worktrees/` 하위에 격리된 워크트리를 생성한다
+- 생성된 워크트리 디렉토리로 작업 디렉토리를 변경한다
 
 ### 5. 이슈 상태 변경
 ```bash
@@ -57,5 +60,6 @@ gh issue edit <이슈번호> --remove-label "status: ready" --add-label "status:
 ✅ 작업 준비 완료
 - 이슈: #<번호> <제목>
 - 브랜치: <브랜치명>
+- 워크트리: .claude/worktrees/<브랜치명>
 - 상태: status: ready → status: in-progress
 ```


### PR DESCRIPTION
## Summary
- start-issue 스킬에서 `git checkout -b` 대신 `git worktree add`로 격리된 작업 환경 생성
- 각 스킬의 model 설정을 작업 복잡도에 맞게 최적화 (start-issue: sonnet→haiku, review-pr: sonnet→opus)

## Changes
- `.claude/skills/start-issue/SKILL.md`: 워크트리 기반으로 변경, model을 haiku로 조정
- `.claude/skills/review-pr/SKILL.md`: model을 opus로 조정

## Related Issue
Closes #16

## Test Plan
- [ ] `npm run check` pass
- [ ] start-issue 스킬 실행 시 워크트리가 정상 생성되는지 확인
- [ ] 각 스킬의 model이 올바르게 적용되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)