### PR TITLE
feat(api): generate workflow progress dynamically from agent keys

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -202,12 +202,11 @@ fn build_snapshot(state: &State) -> Snapshot {
         sources,
         recent: state.recent.iter().take(300).cloned().collect(),
         alerts: state.alerts.iter().take(20).cloned().collect(),
-        workflow_progress: vec![
-            workflow_row(state, "lead"),
-            workflow_row(state, "designer"),
-            workflow_row(state, "frontend"),
-            workflow_row(state, "backend"),
-        ],
+        workflow_progress: {
+            let mut keys: Vec<&String> = state.by_agent.keys().collect();
+            keys.sort();
+            keys.iter().map(|k| workflow_row(state, k)).collect()
+        },
     }
 }
 


### PR DESCRIPTION
## Summary
- `build_snapshot()`의 하드코딩된 4개 역할(lead/designer/frontend/backend)을 동적 생성으로 교체
- `state.by_agent.keys()`를 정렬하여 이벤트를 수신한 에이전트만 워크플로우 행으로 생성

## Changes
- `src/main.rs` L205-210: `workflow_progress` 필드를 `by_agent.keys()` 기반 동적 생성으로 변경

## Related Issue
Closes #5

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass
- [ ] `npm run check` pass
- [ ] 에이전트 이벤트 수신 시 `workflow_progress` 동적 생성 확인
- [ ] 에이전트 없을 때 빈 배열 `[]` 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)