### PR TITLE
feat: add branch sync step to pr skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -18,9 +18,13 @@ model: sonnet
 
 ## Instructions
 
-1. Ensure the branch is pushed to remote. If not, push with `git push -u origin <branch>`
-2. Analyze all commits from `main` to `HEAD` — not just the latest commit
-3. Create a PR using `gh pr create` with the following format:
+1. 브랜치 최신화
+   - `git fetch origin main`으로 최신 main을 가져온다
+   - `git rebase origin/main`으로 현재 브랜치를 최신화한다
+   - 충돌이 발생하면 `git rebase --abort`로 롤백하고, 사용자에게 충돌 파일 목록을 안내한 뒤 중단한다
+2. Ensure the branch is pushed to remote. If not, push with `git push -u origin <branch>`
+3. Analyze all commits from `main` to `HEAD` — not just the latest commit
+4. Create a PR using `gh pr create` with the following format:
 
 ```bash
 gh pr create --title "<title>" --body "$(cat <<'EOF'
@@ -45,9 +49,9 @@ EOF
 )"
 ```
 
-4. 관련 이슈 번호 결정:
+5. 관련 이슈 번호 결정:
    - `$ARGUMENTS`가 있으면 해당 값을 사용
    - 없으면 브랜치명 끝의 숫자를 이슈 번호로 추출 (예: `feat/add-cache-18` → `18`)
    - `Closes #<이슈번호>`를 PR 본문에 포함
-5. Keep the PR title under 70 characters and follow conventional commit style
-6. Return the PR URL when done
+6. Keep the PR title under 70 characters and follow conventional commit style
+7. Return the PR URL when done


### PR DESCRIPTION
## Summary
- `/pr` 스킬에 브랜치 최신화 단계를 추가하여 PR 생성 전 main 대비 충돌을 방지

## Changes
- `git fetch origin main` → `git rebase origin/main` 단계 추가 (Instructions 1번)
- 충돌 발생 시 `git rebase --abort`로 롤백하고 사용자에게 안내 후 중단하는 로직 명시
- 기존 Instructions 번호 재정렬 (1→7)

## Related Issue
Closes #27

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] `/pr` 스킬 실행 시 rebase 단계가 정상 수행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)