### PR TITLE
test(api): src/main.rs 테스트 코드 추가하여 커버리지 81% 달성

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1083,3 +1083,1068 @@ fn main() {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_app() -> App {
+        make_test_app_with_dir(PathBuf::from("public"))
+    }
+
+    fn make_test_app_with_dir(path: PathBuf) -> App {
+        App {
+            state: Arc::new(Mutex::new(State::default())),
+            sse_clients: Arc::new(Mutex::new(Vec::new())),
+            event_seq: Arc::new(AtomicU64::new(1)),
+            public_dir: Arc::new(path),
+            api_key: None,
+        }
+    }
+
+    fn spawn_test_server(app: App) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            handle_client(stream, app);
+        });
+        (addr, handle)
+    }
+
+    fn make_test_event(status: &str, event: &str, agent_id: &str, metadata: Value) -> Event {
+        Event {
+            id: "e0".to_string(),
+            agent_id: agent_id.to_string(),
+            event: event.to_string(),
+            status: status.to_string(),
+            latency_ms: None,
+            message: "test".to_string(),
+            metadata,
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            received_at: "2025-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    // ── A. 순수 함수 테스트 ──
+
+    #[test]
+    fn test_now_iso_returns_nonempty_rfc3339() {
+        let result = now_iso();
+        assert!(!result.is_empty());
+        assert!(result.contains('T'));
+        assert!(result.ends_with('Z') || result.contains('+'));
+    }
+
+    #[test]
+    fn test_status_norm_error() {
+        assert_eq!(status_norm("error"), "error");
+        assert_eq!(status_norm("ERROR"), "error");
+        assert_eq!(status_norm("Error"), "error");
+    }
+
+    #[test]
+    fn test_status_norm_warning() {
+        assert_eq!(status_norm("warning"), "warning");
+        assert_eq!(status_norm("WARNING"), "warning");
+        assert_eq!(status_norm("Warning"), "warning");
+    }
+
+    #[test]
+    fn test_status_norm_ok_default() {
+        assert_eq!(status_norm("ok"), "ok");
+        assert_eq!(status_norm(""), "ok");
+        assert_eq!(status_norm("success"), "ok");
+        assert_eq!(status_norm("anything"), "ok");
+    }
+
+    #[test]
+    fn test_json_response_format() {
+        let resp = json_response("200 OK", r#"{"ok":true}"#);
+        let text = String::from_utf8(resp).unwrap();
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Type: application/json"));
+        assert!(text.contains("Content-Length: 11"));
+        assert!(text.ends_with(r#"{"ok":true}"#));
+    }
+
+    #[test]
+    fn test_json_response_404() {
+        let resp = json_response("404 Not Found", r#"{"error":"nope"}"#);
+        let text = String::from_utf8(resp).unwrap();
+        assert!(text.starts_with("HTTP/1.1 404 Not Found\r\n"));
+        assert!(text.contains(r#"{"error":"nope"}"#));
+    }
+
+    #[test]
+    fn test_bytes_response_format() {
+        let body = b"hello world";
+        let resp = bytes_response("200 OK", body, "text/plain");
+        let text = String::from_utf8(resp).unwrap();
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Type: text/plain"));
+        assert!(text.contains("Content-Length: 11"));
+        assert!(text.ends_with("hello world"));
+    }
+
+    #[test]
+    fn test_content_type_for_html() {
+        assert_eq!(content_type_for("index.html"), "text/html; charset=utf-8");
+    }
+
+    #[test]
+    fn test_content_type_for_css() {
+        assert_eq!(content_type_for("style.css"), "text/css; charset=utf-8");
+    }
+
+    #[test]
+    fn test_content_type_for_js() {
+        assert_eq!(
+            content_type_for("app.js"),
+            "application/javascript; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_json() {
+        assert_eq!(
+            content_type_for("data.json"),
+            "application/json; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_unknown() {
+        assert_eq!(content_type_for("file.bin"), "application/octet-stream");
+        assert_eq!(content_type_for("archive.tar"), "application/octet-stream");
+    }
+
+    // ── B. State 기반 함수 테스트 ──
+
+    #[test]
+    fn test_workflow_row_idle_when_agent_missing() {
+        let state = State::default();
+        let row = workflow_row(&state, "missing-agent");
+        assert_eq!(row.role_id, "missing-agent");
+        assert!(!row.active);
+        assert_eq!(row.status, "idle");
+        assert_eq!(row.total, 0);
+        assert!(row.last_seen.is_none());
+    }
+
+    #[test]
+    fn test_workflow_row_running() {
+        let mut state = State::default();
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                total: 5,
+                ok: 5,
+                warning: 0,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "heartbeat".to_string(),
+                latency_ms: None,
+            },
+        );
+        let row = workflow_row(&state, "agent-1");
+        assert!(row.active);
+        assert_eq!(row.status, "running");
+        assert_eq!(row.total, 5);
+    }
+
+    #[test]
+    fn test_workflow_row_at_risk() {
+        let mut state = State::default();
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                total: 3,
+                ok: 1,
+                warning: 2,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "warn".to_string(),
+                latency_ms: None,
+            },
+        );
+        let row = workflow_row(&state, "agent-1");
+        assert_eq!(row.status, "at-risk");
+    }
+
+    #[test]
+    fn test_workflow_row_blocked() {
+        let mut state = State::default();
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                total: 2,
+                ok: 0,
+                warning: 1,
+                error: 1,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "error".to_string(),
+                latency_ms: None,
+            },
+        );
+        let row = workflow_row(&state, "agent-1");
+        assert_eq!(row.status, "blocked");
+    }
+
+    #[test]
+    fn test_build_snapshot_empty_state() {
+        let state = State::default();
+        let snap = build_snapshot(&state);
+        assert!(snap.agents.is_empty());
+        assert!(snap.sources.is_empty());
+        assert!(snap.recent.is_empty());
+        assert!(snap.alerts.is_empty());
+        assert!(snap.workflow_progress.is_empty());
+        assert_eq!(snap.totals["agents"], 0);
+    }
+
+    #[test]
+    fn test_build_snapshot_with_agents() {
+        let mut state = State::default();
+        state.by_agent.insert(
+            "a1".to_string(),
+            AgentRow {
+                agent_id: "a1".to_string(),
+                last_seen: now_iso(),
+                total: 10,
+                ok: 7,
+                warning: 2,
+                error: 1,
+                token_total: 100,
+                cost_usd: 0.5,
+                last_event: "test".to_string(),
+                latency_ms: Some(42),
+            },
+        );
+        state.by_agent.insert(
+            "a2".to_string(),
+            AgentRow {
+                agent_id: "a2".to_string(),
+                last_seen: now_iso(),
+                total: 5,
+                ok: 5,
+                warning: 0,
+                error: 0,
+                token_total: 50,
+                cost_usd: 0.1,
+                last_event: "ok".to_string(),
+                latency_ms: None,
+            },
+        );
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.agents.len(), 2);
+        assert_eq!(snap.totals["agents"], 2);
+        assert_eq!(snap.totals["total"], 15);
+        assert_eq!(snap.totals["ok"], 12);
+        assert_eq!(snap.totals["warning"], 2);
+        assert_eq!(snap.totals["error"], 1);
+        assert_eq!(snap.totals["tokenTotal"], 150);
+        assert_eq!(snap.workflow_progress.len(), 2);
+    }
+
+    #[test]
+    fn test_normalize_incoming_full_payload() {
+        let app = make_test_app();
+        let payload = json!({
+            "agentId": "bot-1",
+            "event": "task_complete",
+            "status": "ok",
+            "latencyMs": 123,
+            "message": "done",
+            "timestamp": "2025-06-01T00:00:00Z",
+            "metadata": { "source": "test" }
+        });
+        let evt = normalize_incoming(&payload, &app);
+        assert_eq!(evt.agent_id, "bot-1");
+        assert_eq!(evt.event, "task_complete");
+        assert_eq!(evt.status, "ok");
+        assert_eq!(evt.latency_ms, Some(123));
+        assert_eq!(evt.message, "done");
+        assert_eq!(evt.timestamp, "2025-06-01T00:00:00Z");
+        assert!(evt.id.starts_with('e'));
+    }
+
+    #[test]
+    fn test_normalize_incoming_missing_fields() {
+        let app = make_test_app();
+        let payload = json!({});
+        let evt = normalize_incoming(&payload, &app);
+        assert_eq!(evt.agent_id, "unknown-agent");
+        assert_eq!(evt.event, "heartbeat");
+        assert_eq!(evt.status, "ok");
+        assert_eq!(evt.latency_ms, None);
+        assert_eq!(evt.message, "");
+    }
+
+    #[test]
+    fn test_normalize_incoming_status_normalized() {
+        let app = make_test_app();
+        let payload = json!({ "status": "ERROR" });
+        let evt = normalize_incoming(&payload, &app);
+        assert_eq!(evt.status, "error");
+    }
+
+    #[test]
+    fn test_append_event_adds_to_recent() {
+        let app = make_test_app();
+        let evt = make_test_event("ok", "ping", "agent-1", json!({}));
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.recent.len(), 1);
+        assert_eq!(state.recent[0].event, "ping");
+    }
+
+    #[test]
+    fn test_append_event_updates_agent_counters() {
+        let app = make_test_app();
+        append_event(&app, make_test_event("ok", "e1", "a1", json!({})));
+        append_event(&app, make_test_event("error", "e2", "a1", json!({})));
+        append_event(&app, make_test_event("warning", "e3", "a1", json!({})));
+        let state = app.state.lock().unwrap();
+        let row = &state.by_agent["a1"];
+        assert_eq!(row.total, 3);
+        assert_eq!(row.ok, 1);
+        assert_eq!(row.error, 1);
+        assert_eq!(row.warning, 1);
+    }
+
+    #[test]
+    fn test_append_event_creates_alerts_for_error_and_warning() {
+        let app = make_test_app();
+        append_event(&app, make_test_event("ok", "e1", "a1", json!({})));
+        append_event(&app, make_test_event("error", "e2", "a1", json!({})));
+        append_event(&app, make_test_event("warning", "e3", "a1", json!({})));
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.alerts.len(), 2);
+        assert_eq!(state.alerts[0].severity, "warning");
+        assert_eq!(state.alerts[1].severity, "error");
+    }
+
+    #[test]
+    fn test_append_event_recent_truncates_at_200() {
+        let app = make_test_app();
+        for i in 0..210 {
+            append_event(
+                &app,
+                make_test_event("ok", &format!("e{}", i), "a1", json!({})),
+            );
+        }
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.recent.len(), 200);
+    }
+
+    #[test]
+    fn test_append_event_alerts_truncates_at_120() {
+        let app = make_test_app();
+        for i in 0..130 {
+            append_event(
+                &app,
+                make_test_event("error", &format!("e{}", i), "a1", json!({})),
+            );
+        }
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.alerts.len(), 120);
+    }
+
+    #[test]
+    fn test_append_event_token_and_cost_accumulation() {
+        let app = make_test_app();
+        let meta = json!({
+            "tokenUsage": { "totalTokens": 100 }
+        });
+        append_event(&app, make_test_event("ok", "msg", "a1", meta));
+        let cost_meta = json!({ "costDelta": 0.05 });
+        append_event(&app, make_test_event("ok", "cost_update", "a1", cost_meta));
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.token_total, 100);
+        assert!((state.cost_total_usd - 0.05).abs() < 1e-9);
+        let row = &state.by_agent["a1"];
+        assert_eq!(row.token_total, 100);
+        assert!((row.cost_usd - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_append_event_source_tracking() {
+        let app = make_test_app();
+        let meta = json!({ "source": "claude_session" });
+        append_event(&app, make_test_event("ok", "e1", "a1", meta.clone()));
+        append_event(&app, make_test_event("error", "e2", "a1", meta));
+        let state = app.state.lock().unwrap();
+        let src = &state.by_source["claude_session"];
+        assert_eq!(src.total, 2);
+        assert_eq!(src.ok, 1);
+        assert_eq!(src.error, 1);
+    }
+
+    #[test]
+    fn test_append_event_default_source_is_manual() {
+        let app = make_test_app();
+        append_event(&app, make_test_event("ok", "e1", "a1", json!({})));
+        let state = app.state.lock().unwrap();
+        assert!(state.by_source.contains_key("manual"));
+    }
+
+    #[test]
+    fn test_append_event_empty_message_becomes_no_message_in_alert() {
+        let app = make_test_app();
+        let mut evt = make_test_event("error", "e1", "a1", json!({}));
+        evt.message = "".to_string();
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.alerts[0].message, "No message");
+    }
+
+    #[test]
+    fn test_broadcast_sse_delivers_to_clients() {
+        let app = make_test_app();
+        let (tx, rx) = mpsc::channel::<String>();
+        app.sse_clients.lock().unwrap().push(tx);
+        broadcast_sse(&app, "hello".to_string());
+        assert_eq!(rx.recv().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_broadcast_sse_removes_disconnected_clients() {
+        let app = make_test_app();
+        let (tx, rx) = mpsc::channel::<String>();
+        app.sse_clients.lock().unwrap().push(tx);
+        drop(rx);
+        broadcast_sse(&app, "hello".to_string());
+        assert_eq!(app.sse_clients.lock().unwrap().len(), 0);
+    }
+
+    // ── C. 파일 I/O 함수 테스트 ──
+
+    fn unique_tmp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("ccm_test_{}_{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_read_delta_lines_empty_file() {
+        let dir = unique_tmp_dir("rdl_empty");
+        let path = dir.join("empty.log");
+        File::create(&path).unwrap();
+        let mut cursor = (0u64, String::new());
+        let lines = read_delta_lines(&path, &mut cursor, 1024);
+        assert!(lines.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_read_delta_lines_new_lines() {
+        let dir = unique_tmp_dir("rdl_new");
+        let path = dir.join("data.log");
+        {
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "line1").unwrap();
+            writeln!(f, "line2").unwrap();
+        }
+        let mut cursor = (0u64, String::new());
+        let lines = read_delta_lines(&path, &mut cursor, 1024);
+        assert_eq!(lines, vec!["line1", "line2"]);
+
+        // second call returns nothing
+        let lines2 = read_delta_lines(&path, &mut cursor, 1024);
+        assert!(lines2.is_empty());
+
+        // append more
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            writeln!(f, "line3").unwrap();
+        }
+        let lines3 = read_delta_lines(&path, &mut cursor, 1024);
+        assert_eq!(lines3, vec!["line3"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_read_delta_lines_file_shrink_resets_cursor() {
+        let dir = unique_tmp_dir("rdl_shrink");
+        let path = dir.join("data.log");
+        {
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "aaaaaa").unwrap();
+            writeln!(f, "bbbbbb").unwrap();
+        }
+        let mut cursor = (0u64, String::new());
+        read_delta_lines(&path, &mut cursor, 1024);
+        assert!(cursor.0 > 0);
+
+        // shrink file
+        {
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "cc").unwrap();
+        }
+        let lines = read_delta_lines(&path, &mut cursor, 1024);
+        assert_eq!(lines, vec!["cc"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_read_delta_lines_max_bytes_limit() {
+        let dir = unique_tmp_dir("rdl_max");
+        let path = dir.join("data.log");
+        {
+            let mut f = File::create(&path).unwrap();
+            for i in 0..100 {
+                writeln!(f, "line{:03}", i).unwrap();
+            }
+        }
+        // read with very small max_read_bytes — only tail portion
+        let mut cursor = (0u64, String::new());
+        let lines = read_delta_lines(&path, &mut cursor, 30);
+        assert!(!lines.is_empty());
+        assert!(lines.len() < 100);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_read_delta_lines_nonexistent_file() {
+        let path = std::env::temp_dir().join("ccm_nonexistent_file_xyz.log");
+        let mut cursor = (0u64, String::new());
+        let lines = read_delta_lines(&path, &mut cursor, 1024);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_walk_jsonl_files_finds_nested() {
+        let dir = unique_tmp_dir("walk");
+        let sub = dir.join("session1");
+        std::fs::create_dir_all(&sub).unwrap();
+        File::create(sub.join("data.jsonl")).unwrap();
+        File::create(sub.join("other.json")).unwrap(); // should be ignored
+        File::create(sub.join("log.jsonl")).unwrap();
+
+        let files = walk_jsonl_files(&dir);
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().all(|p| p.extension().unwrap() == "jsonl"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_walk_jsonl_files_ignores_top_level_files() {
+        let dir = unique_tmp_dir("walk_top");
+        File::create(dir.join("top.jsonl")).unwrap(); // top-level, should be ignored
+        let files = walk_jsonl_files(&dir);
+        assert!(files.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_walk_jsonl_files_nonexistent_dir() {
+        let files = walk_jsonl_files(&std::env::temp_dir().join("ccm_nonexistent_dir_xyz"));
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_history_event_valid() {
+        let app = make_test_app();
+        let line = r#"{"text":"hello world","ts":1700000000,"session_id":"s1"}"#;
+        let evt = parse_history_event(line, &app);
+        assert!(evt.is_some());
+        let evt = evt.unwrap();
+        assert_eq!(evt.agent_id, "lead");
+        assert_eq!(evt.event, "user_request");
+        assert_eq!(evt.message, "hello world");
+        assert!(evt.metadata["sessionId"].as_str().unwrap() == "s1");
+    }
+
+    #[test]
+    fn test_parse_history_event_invalid_json() {
+        let app = make_test_app();
+        assert!(parse_history_event("not json", &app).is_none());
+    }
+
+    #[test]
+    fn test_parse_history_event_missing_text() {
+        let app = make_test_app();
+        assert!(parse_history_event(r#"{"ts":0}"#, &app).is_none());
+    }
+
+    #[test]
+    fn test_parse_history_event_truncates_at_120_chars() {
+        let app = make_test_app();
+        let long_text = "a".repeat(200);
+        let line = format!(r#"{{"text":"{}","ts":0}}"#, long_text);
+        let evt = parse_history_event(&line, &app).unwrap();
+        assert_eq!(evt.message.len(), 120);
+    }
+
+    #[test]
+    fn test_parse_session_line_user_message() {
+        let app = make_test_app();
+        let line = r#"{"type":"user","message":{"content":"hi"},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event, "user_message");
+        assert_eq!(events[0].message, "hi");
+    }
+
+    #[test]
+    fn test_parse_session_line_user_empty_content_ignored() {
+        let app = make_test_app();
+        let line = r#"{"type":"user","message":{"content":""},"sessionId":"s1"}"#;
+        let events = parse_session_line(line, &app);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_session_line_assistant_text_and_tool() {
+        let app = make_test_app();
+        let line = r#"{"type":"assistant","message":{"model":"claude-3","content":[{"type":"text","text":"hello"},{"type":"tool_use","name":"bash","input":{}}]},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event, "assistant_message");
+        assert_eq!(events[0].message, "hello");
+        assert_eq!(events[1].event, "tool_call");
+        assert_eq!(events[1].message, "bash");
+    }
+
+    #[test]
+    fn test_parse_session_line_assistant_with_usage() {
+        let app = make_test_app();
+        let line = r#"{"type":"assistant","message":{"model":"claude-3","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10}},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert_eq!(events.len(), 2); // text + token_usage
+        assert_eq!(events[1].event, "token_usage");
+        assert!(events[1].message.contains("150"));
+    }
+
+    #[test]
+    fn test_parse_session_line_unknown_type_ignored() {
+        let app = make_test_app();
+        let line = r#"{"type":"system","message":{},"sessionId":"s1"}"#;
+        let events = parse_session_line(line, &app);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_session_line_invalid_json() {
+        let app = make_test_app();
+        let events = parse_session_line("not json", &app);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_session_line_assistant_empty_text_ignored() {
+        let app = make_test_app();
+        let line = r#"{"type":"assistant","message":{"model":"m","content":[{"type":"text","text":""}]},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_poll_stats_cache_first_read_returns_none() {
+        let dir = unique_tmp_dir("psc_first");
+        let path = dir.join("stats-cache.json");
+        {
+            let mut f = File::create(&path).unwrap();
+            write!(f, r#"{{"modelUsage":{{"m1":{{"costUSD":1.5}}}}}}"#).unwrap();
+        }
+        let app = make_test_app();
+        let mut last_mtime: Option<SystemTime> = None;
+        let mut last_cost = 0.0_f64;
+        let result = poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+        assert!(result.is_none());
+        assert!(last_mtime.is_some());
+        assert!((last_cost - 1.5).abs() < 1e-9);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_poll_stats_cache_no_change_returns_none() {
+        let dir = unique_tmp_dir("psc_nochange");
+        let path = dir.join("stats-cache.json");
+        {
+            let mut f = File::create(&path).unwrap();
+            write!(f, r#"{{"modelUsage":{{"m1":{{"costUSD":1.0}}}}}}"#).unwrap();
+        }
+        let app = make_test_app();
+        let mut last_mtime: Option<SystemTime> = None;
+        let mut last_cost = 0.0_f64;
+        poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+        // second call without file change
+        let result = poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+        assert!(result.is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_poll_stats_cache_cost_increase_returns_event() {
+        let dir = unique_tmp_dir("psc_increase");
+        let path = dir.join("stats-cache.json");
+        {
+            let mut f = File::create(&path).unwrap();
+            write!(f, r#"{{"modelUsage":{{"m1":{{"costUSD":1.0}}}}}}"#).unwrap();
+        }
+        let app = make_test_app();
+        let mut last_mtime: Option<SystemTime> = None;
+        let mut last_cost = 0.0_f64;
+        poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+
+        // simulate file update with cost increase — sleep 1s to guarantee mtime change
+        thread::sleep(Duration::from_secs(1));
+        {
+            let mut f = File::create(&path).unwrap();
+            write!(f, r#"{{"modelUsage":{{"m1":{{"costUSD":2.5}}}}}}"#).unwrap();
+        }
+        let result = poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+        assert!(result.is_some());
+        let evt = result.unwrap();
+        assert_eq!(evt.event, "cost_update");
+        assert!((last_cost - 2.5).abs() < 1e-9);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_poll_stats_cache_nonexistent_returns_none() {
+        let app = make_test_app();
+        let mut last_mtime: Option<SystemTime> = None;
+        let mut last_cost = 0.0_f64;
+        let result = poll_stats_cache(
+            &std::env::temp_dir().join("ccm_nonexistent_stats.json"),
+            &app,
+            &mut last_mtime,
+            &mut last_cost,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_poll_session_files_integrates_events() {
+        let dir = unique_tmp_dir("psf");
+        let sub = dir.join("proj1");
+        std::fs::create_dir_all(&sub).unwrap();
+        {
+            let mut f = File::create(sub.join("session.jsonl")).unwrap();
+            writeln!(f, r#"{{"type":"user","message":{{"content":"hello"}},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}}"#).unwrap();
+        }
+        let app = make_test_app();
+        let mut cursors: HashMap<PathBuf, (u64, String)> = HashMap::new();
+        poll_session_files(&dir, &app, &mut cursors);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.recent.len(), 1);
+        assert_eq!(state.recent[0].event, "user_message");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── D. serve_static 테스트 ──
+
+    #[test]
+    fn test_serve_static_200_ok() {
+        let dir = unique_tmp_dir("ss_200");
+        {
+            let mut f = File::create(dir.join("hello.html")).unwrap();
+            write!(f, "<h1>Hi</h1>").unwrap();
+        }
+        let app = make_test_app_with_dir(dir.clone());
+        let resp = String::from_utf8(serve_static(&app, "/hello.html")).unwrap();
+        assert!(resp.starts_with("HTTP/1.1 200 OK"));
+        assert!(resp.contains("text/html"));
+        assert!(resp.contains("<h1>Hi</h1>"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_serve_static_index_redirect() {
+        let dir = unique_tmp_dir("ss_index");
+        {
+            let mut f = File::create(dir.join("index.html")).unwrap();
+            write!(f, "index").unwrap();
+        }
+        let app = make_test_app_with_dir(dir.clone());
+        let resp = String::from_utf8(serve_static(&app, "/")).unwrap();
+        assert!(resp.starts_with("HTTP/1.1 200 OK"));
+        assert!(resp.contains("index"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_serve_static_404() {
+        let dir = unique_tmp_dir("ss_404");
+        let app = make_test_app_with_dir(dir.clone());
+        let resp = String::from_utf8(serve_static(&app, "/missing.html")).unwrap();
+        assert!(resp.contains("404 Not Found"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_serve_static_403_path_traversal() {
+        let dir = unique_tmp_dir("ss_403");
+        std::fs::create_dir_all(&dir).unwrap();
+        {
+            let mut f = File::create(dir.join("safe.html")).unwrap();
+            write!(f, "safe").unwrap();
+        }
+        let app = make_test_app_with_dir(dir.clone());
+        let resp = String::from_utf8(serve_static(&app, "/../../../etc/passwd")).unwrap();
+        assert!(resp.contains("403") || resp.contains("404"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── E. handle_client 통합 테스트 ──
+
+    fn http_request(addr: &str, request: &str) -> String {
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream
+            .set_write_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        stream.write_all(request.as_bytes()).unwrap();
+        let mut buf = Vec::new();
+        let _ = stream.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    #[test]
+    fn test_handle_client_health() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(&addr, "GET /api/health HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        handle.join().unwrap();
+        assert!(resp.contains("200 OK"));
+        assert!(resp.contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn test_handle_client_get_events() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(&addr, "GET /api/events HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        handle.join().unwrap();
+        assert!(resp.contains("200 OK"));
+        assert!(resp.contains("generatedAt"));
+    }
+
+    #[test]
+    fn test_handle_client_get_alerts() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(&addr, "GET /api/alerts HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        handle.join().unwrap();
+        assert!(resp.contains("200 OK"));
+        assert!(resp.contains("alerts"));
+    }
+
+    #[test]
+    fn test_handle_client_post_events_valid() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let body = r#"{"agentId":"a1","event":"test","status":"ok"}"#;
+        let req = format!(
+            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let resp = http_request(&addr, &req);
+        handle.join().unwrap();
+        assert!(resp.contains("202 Accepted"));
+        assert!(resp.contains("\"accepted\":true"));
+    }
+
+    #[test]
+    fn test_handle_client_post_events_invalid_json() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let body = "not json";
+        let req = format!(
+            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let resp = http_request(&addr, &req);
+        handle.join().unwrap();
+        assert!(resp.contains("400 Bad Request"));
+    }
+
+    #[test]
+    fn test_handle_client_post_events_auth_required() {
+        let mut app = make_test_app();
+        app.api_key = Some("secret123".to_string());
+        let (addr, handle) = spawn_test_server(app);
+        let body = r#"{"agentId":"a1"}"#;
+        let req = format!(
+            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\nX-Api-Key: wrong\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let resp = http_request(&addr, &req);
+        handle.join().unwrap();
+        assert!(resp.contains("401 Unauthorized"));
+    }
+
+    #[test]
+    fn test_handle_client_post_events_auth_success() {
+        let mut app = make_test_app();
+        app.api_key = Some("secret123".to_string());
+        let (addr, handle) = spawn_test_server(app);
+        let body = r#"{"agentId":"a1"}"#;
+        let req = format!(
+            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\nX-Api-Key: secret123\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let resp = http_request(&addr, &req);
+        handle.join().unwrap();
+        assert!(resp.contains("202 Accepted"));
+    }
+
+    #[test]
+    fn test_workflow_row_idle_with_zero_total() {
+        let mut state = State::default();
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                total: 0,
+                ok: 0,
+                warning: 0,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "-".to_string(),
+                latency_ms: None,
+            },
+        );
+        let row = workflow_row(&state, "agent-1");
+        assert!(row.active);
+        assert_eq!(row.status, "idle");
+    }
+
+    #[test]
+    fn test_parse_session_line_assistant_unknown_content_item() {
+        let app = make_test_app();
+        let line = r#"{"type":"assistant","message":{"model":"m","content":[{"type":"image","url":"x"}]},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_poll_stats_cache_cost_decrease_returns_none() {
+        let dir = unique_tmp_dir("psc_decrease");
+        let path = dir.join("stats-cache.json");
+        {
+            let mut f = File::create(&path).unwrap();
+            write!(f, r#"{{"modelUsage":{{"m1":{{"costUSD":5.0}}}}}}"#).unwrap();
+        }
+        let app = make_test_app();
+        let mut last_mtime: Option<SystemTime> = None;
+        let mut last_cost = 0.0_f64;
+        poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+
+        // write a lower cost — sleep 1s to guarantee mtime change on all filesystems
+        thread::sleep(Duration::from_secs(1));
+        {
+            let mut f = File::create(&path).unwrap();
+            write!(f, r#"{{"modelUsage":{{"m1":{{"costUSD":3.0}}}}}}"#).unwrap();
+        }
+        let result = poll_stats_cache(&path, &app, &mut last_mtime, &mut last_cost);
+        assert!(result.is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_serve_static_nonexistent_public_dir() {
+        let nonexistent = std::env::temp_dir().join("ccm_nonexistent_public_xyz");
+        let app = make_test_app_with_dir(nonexistent);
+        let resp = String::from_utf8(serve_static(&app, "/index.html")).unwrap();
+        assert!(resp.contains("404") || resp.contains("500"));
+    }
+
+    #[test]
+    fn test_handle_client_static_file() {
+        let dir = unique_tmp_dir("hc_static");
+        {
+            let mut f = File::create(dir.join("page.html")).unwrap();
+            write!(f, "<p>hello</p>").unwrap();
+        }
+        let app = make_test_app_with_dir(dir.clone());
+        let (addr, handle) = spawn_test_server(app);
+        let resp = http_request(&addr, "GET /page.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        handle.join().unwrap();
+        assert!(resp.contains("200 OK"));
+        assert!(resp.contains("<p>hello</p>"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_handle_client_query_string_stripped() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(
+            &addr,
+            "GET /api/health?ts=123 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        );
+        handle.join().unwrap();
+        assert!(resp.contains("200 OK"));
+        assert!(resp.contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn test_handle_client_sse_stream() {
+        let app = make_test_app();
+        let app_ref = app.clone();
+        let (addr, handle) = spawn_test_server(app);
+
+        let mut stream = TcpStream::connect(&addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        stream
+            .write_all(b"GET /api/stream HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+
+        // read all available data (header + initial snapshot)
+        let mut all = Vec::new();
+        let mut buf = [0u8; 8192];
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    all.extend_from_slice(&buf[..n]);
+                    let s = String::from_utf8_lossy(&all);
+                    if s.contains("text/event-stream") && s.contains("data:") {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        let resp = String::from_utf8_lossy(&all);
+        assert!(resp.contains("text/event-stream"));
+
+        // disconnect client then trigger broadcast to exit handle_sse
+        drop(stream);
+        broadcast_sse(&app_ref, "trigger_exit".to_string());
+
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_handle_client_method_not_allowed() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(
+            &addr,
+            "DELETE /api/events HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        );
+        handle.join().unwrap();
+        assert!(resp.contains("405 Method Not Allowed"));
+    }
+}


### PR DESCRIPTION
## Summary
- `src/main.rs`에 `#[cfg(test)]` 모듈 추가, 테스트 75개 작성
- `cargo tarpaulin --fail-under 80` 통과: 81.23% (476/586 lines)

## Changes
- 순수 함수 테스트 (A): `now_iso`, `status_norm`, `json_response`, `bytes_response`, `content_type_for`
- State 기반 테스트 (B): `workflow_row`, `build_snapshot`, `normalize_incoming`, `append_event`, `broadcast_sse`
- 파일 I/O 테스트 (C): `read_delta_lines`, `walk_jsonl_files`, `parse_history_event`, `parse_session_line`, `poll_stats_cache`, `poll_session_files`
- serve_static 테스트 (D): 200/404/403/index.html/nonexistent 케이스
- handle_client 통합 테스트 (E): 로컬 TCP 연결 기반 9개 라우팅 케이스
- 테스트 헬퍼: `spawn_test_server()`, `make_test_app()`, `unique_tmp_dir()`

## Related Issue
Closes #32

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (75/75)
- [x] `cargo tarpaulin --fail-under 80` pass (81.23%)
- [ ] `npm run check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)