### PR TITLE
feat(ui): 프론트엔드 브랜딩을 Codex에서 Claude로 변경

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -44,7 +44,7 @@ function createWindow() {
     height: 840,
     minWidth: 980,
     minHeight: 700,
-    title: 'Codex Pulse',
+    title: 'Claude Pulse',
     autoHideMenuBar: true,
     webPreferences: {
       contextIsolation: true,

--- a/public/app.js
+++ b/public/app.js
@@ -313,7 +313,7 @@ function renderTokenTrendChart(events = []) {
 
   if (!agents.length) {
     tokenTrendChart.innerHTML = `
-      <title>에이전트별 분당 토큰 사용량 추이 차트</title>
+      <title>모델별 분당 토큰 사용량 추이 차트</title>
       <line x1="36" y1="190" x2="620" y2="190" stroke="rgb(226 109 92 / 45%)" stroke-width="1" />
     `;
     tokenTrendLegend.innerHTML = '<span>No token data</span>';
@@ -354,7 +354,7 @@ function renderTokenTrendChart(events = []) {
     .join('');
 
   tokenTrendChart.innerHTML = `
-    <title>에이전트별 분당 토큰 사용량 추이 차트</title>
+    <title>모델별 분당 토큰 사용량 추이 차트</title>
     <line x1="${width.left}" y1="${height.bottom}" x2="${width.right}" y2="${height.bottom}" stroke="rgb(226 109 92 / 45%)" stroke-width="1" />
     <line x1="${width.left}" y1="${height.top}" x2="${width.left}" y2="${height.bottom}" stroke="rgb(226 109 92 / 30%)" stroke-width="1" />
     <line x1="${width.left}" y1="${midY}" x2="${width.right}" y2="${midY}" stroke="rgb(226 109 92 / 15%)" stroke-width="1" stroke-dasharray="4 4" />

--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Codex Pulse</title>
+    <title>Claude Pulse</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <header class="header">
-      <h1>Codex Pulse</h1>
-      <p>Codex Pulse 실시간 이벤트/상태 모니터링</p>
+      <h1>Claude Pulse</h1>
+      <p>Claude Code 실시간 이벤트/상태 모니터링</p>
       <div class="header-meta">
         <small id="clock"></small>
         <span id="connection" class="status-pill" data-status="reconnecting">reconnecting</span>
@@ -28,8 +28,8 @@
             <div id="throughputTooltip" class="chart-tooltip" hidden></div>
           </article>
           <article class="chart-card">
-            <h3>에이전트별 토큰 추이 (분당)</h3>
-            <svg id="tokenTrendChart" class="token-trend-chart" role="img" aria-label="에이전트별 분당 토큰 사용량 추이 차트" viewBox="0 0 640 220" preserveAspectRatio="none"></svg>
+            <h3>모델별 토큰 추이 (분당)</h3>
+            <svg id="tokenTrendChart" class="token-trend-chart" role="img" aria-label="모델별 분당 토큰 사용량 추이 차트" viewBox="0 0 640 220" preserveAspectRatio="none"></svg>
             <div id="tokenTrendLegend" class="token-legend"></div>
           </article>
         </div>
@@ -41,14 +41,14 @@
       </section>
 
       <section class="panel">
-        <h2>Local Codex Feed</h2>
+        <h2>Local Claude Feed</h2>
         <div class="workflow" id="sources"></div>
       </section>
 
       <section class="panel">
         <div class="panel-head">
-          <h2>Agent 상태</h2>
-          <label for="agentFilter">Role Filter</label>
+          <h2>Model 상태</h2>
+          <label for="agentFilter">Model Filter</label>
           <select id="agentFilter">
             <option value="all">all</option>
           </select>

--- a/server.js
+++ b/server.js
@@ -288,5 +288,5 @@ const server = createServer(async (req, res) => {
 });
 
 server.listen(PORT, HOST, () => {
-  console.log(`Codex Pulse listening on http://${HOST}:${PORT}`);
+  console.log(`Claude Pulse listening on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- 대시보드 UI 전반의 `Codex Pulse` 브랜딩을 `Claude Pulse`로 교체
- Agent/Role 중심 용어를 Model 중심으로 변경 (에이전트별 → 모델별, Role Filter → Model Filter)
- server.js 콘솔 출력 및 Electron 윈도우 타이틀 통일

## Changes
- `public/index.html`: title, h1, 부제목, 토큰 차트, 피드, 상태 섹션, 필터 라벨 변경
- `public/app.js`: SVG `<title>` 에이전트별 → 모델별 (2곳)
- `server.js`: 콘솔 출력 `Codex Pulse` → `Claude Pulse`
- `desktop/main.js`: Electron 윈도우 타이틀 `Codex Pulse` → `Claude Pulse`

## Related Issue
Closes #10

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] 브라우저에서 대시보드 title/h1이 "Claude Pulse"인지 확인
- [ ] 토큰 차트 제목이 "모델별 토큰 추이"인지 확인
- [ ] 피드 섹션이 "Local Claude Feed"인지 확인
- [ ] 서버 시작 시 콘솔에 "Claude Pulse listening on"이 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)