### PR TITLE
feat(api): server-logic.js 분리 및 워크플로우 동적 생성 테스트 추가

### DIFF
--- a/__tests__/server-logic.test.js
+++ b/__tests__/server-logic.test.js
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { roleProgressRow, buildSnapshot } from '../server-logic.js';
+
+describe('roleProgressRow', () => {
+  it('returns idle when roleId is not in byAgent', () => {
+    const byAgent = new Map();
+    const result = roleProgressRow(byAgent, 'unknown');
+    assert.deepStrictEqual(result, {
+      roleId: 'unknown',
+      active: false,
+      status: 'idle',
+      total: 0,
+      lastEvent: '-',
+      lastSeen: null
+    });
+  });
+
+  it('returns blocked when agent has errors', () => {
+    const byAgent = new Map([
+      ['agent-a', { agentId: 'agent-a', lastSeen: '2026-01-01T00:00:00Z', total: 5, ok: 3, warning: 1, error: 1, lastEvent: 'deploy', latencyMs: 100 }]
+    ]);
+    const result = roleProgressRow(byAgent, 'agent-a');
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.active, true);
+    assert.equal(result.total, 5);
+  });
+
+  it('returns at-risk when agent has warnings but no errors', () => {
+    const byAgent = new Map([
+      ['agent-b', { agentId: 'agent-b', lastSeen: '2026-01-01T00:00:00Z', total: 3, ok: 2, warning: 1, error: 0, lastEvent: 'build', latencyMs: 50 }]
+    ]);
+    const result = roleProgressRow(byAgent, 'agent-b');
+    assert.equal(result.status, 'at-risk');
+    assert.equal(result.active, true);
+  });
+
+  it('returns running when agent has only ok events', () => {
+    const byAgent = new Map([
+      ['agent-c', { agentId: 'agent-c', lastSeen: '2026-01-01T00:00:00Z', total: 10, ok: 10, warning: 0, error: 0, lastEvent: 'heartbeat', latencyMs: 20 }]
+    ]);
+    const result = roleProgressRow(byAgent, 'agent-c');
+    assert.equal(result.status, 'running');
+    assert.equal(result.active, true);
+    assert.equal(result.total, 10);
+  });
+});
+
+describe('buildSnapshot', () => {
+  it('returns empty workflowProgress when byAgent is empty', () => {
+    const state = {
+      recent: [],
+      alerts: [],
+      byAgent: new Map(),
+      bySource: new Map()
+    };
+    const snap = buildSnapshot(state);
+    assert.deepStrictEqual(snap.workflowProgress, []);
+    assert.equal(snap.totals.agents, 0);
+  });
+
+  it('generates workflowProgress dynamically from byAgent keys', () => {
+    const state = {
+      recent: [],
+      alerts: [],
+      byAgent: new Map([
+        ['frontend', { agentId: 'frontend', lastSeen: '2026-01-01T00:00:00Z', total: 2, ok: 2, warning: 0, error: 0, lastEvent: 'render', latencyMs: 10 }],
+        ['backend', { agentId: 'backend', lastSeen: '2026-01-01T00:00:00Z', total: 3, ok: 3, warning: 0, error: 0, lastEvent: 'query', latencyMs: 30 }]
+      ]),
+      bySource: new Map()
+    };
+    const snap = buildSnapshot(state);
+    assert.equal(snap.workflowProgress.length, 2);
+    assert.equal(snap.workflowProgress[0].roleId, 'backend');
+    assert.equal(snap.workflowProgress[1].roleId, 'frontend');
+  });
+
+  it('sorts workflowProgress alphabetically by agent key', () => {
+    const state = {
+      recent: [],
+      alerts: [],
+      byAgent: new Map([
+        ['zulu', { agentId: 'zulu', lastSeen: '2026-01-01T00:00:00Z', total: 1, ok: 1, warning: 0, error: 0, lastEvent: 'ping', latencyMs: 5 }],
+        ['alpha', { agentId: 'alpha', lastSeen: '2026-01-01T00:00:00Z', total: 1, ok: 1, warning: 0, error: 0, lastEvent: 'ping', latencyMs: 5 }],
+        ['mike', { agentId: 'mike', lastSeen: '2026-01-01T00:00:00Z', total: 1, ok: 1, warning: 0, error: 0, lastEvent: 'ping', latencyMs: 5 }]
+      ]),
+      bySource: new Map()
+    };
+    const snap = buildSnapshot(state);
+    const ids = snap.workflowProgress.map(r => r.roleId);
+    assert.deepStrictEqual(ids, ['alpha', 'mike', 'zulu']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "desktop:start": "electron .",
     "test:js": "node --test 'public/__tests__/**/*.test.js'",
     "test:collector": "node --test scripts/__tests__/claude-local-collector.test.js",
-    "check": "node --check server.js && node --check simulator.js && node --check scripts/frontend-load-test.js && node --check scripts/claude-local-collector.js && node --check scripts/__tests__/claude-local-collector.test.js && node --check public/app.js && node --check public/lib/workflow.js && node --check desktop/main.js"
+    "test:server": "node --test '__tests__/server-logic.test.js'",
+    "check": "node --check server.js && node --check server-logic.js && node --check simulator.js && node --check scripts/frontend-load-test.js && node --check scripts/claude-local-collector.js && node --check scripts/__tests__/claude-local-collector.test.js && node --check public/app.js && node --check public/lib/workflow.js && node --check desktop/main.js"
   },
   "devDependencies": {
     "electron": "^35.0.0"

--- a/server-logic.js
+++ b/server-logic.js
@@ -1,0 +1,56 @@
+export function roleProgressRow(byAgent, roleId) {
+  const row = byAgent.get(roleId);
+  if (!row) {
+    return {
+      roleId,
+      active: false,
+      status: 'idle',
+      total: 0,
+      lastEvent: '-',
+      lastSeen: null
+    };
+  }
+
+  const status =
+    row.error > 0 ? 'blocked' :
+    row.warning > 0 ? 'at-risk' :
+    row.total > 0 ? 'running' :
+    'idle';
+
+  return {
+    roleId,
+    active: true,
+    status,
+    total: row.total,
+    lastEvent: row.lastEvent,
+    lastSeen: row.lastSeen
+  };
+}
+
+export function buildSnapshot(state) {
+  const agentRows = [...state.byAgent.values()].sort((a, b) =>
+    a.agentId.localeCompare(b.agentId)
+  );
+
+  const totals = agentRows.reduce(
+    (acc, row) => {
+      acc.total += row.total;
+      acc.ok += row.ok;
+      acc.warning += row.warning;
+      acc.error += row.error;
+      return acc;
+    },
+    { agents: agentRows.length, total: 0, ok: 0, warning: 0, error: 0 }
+  );
+  const sources = [...state.bySource.values()].sort((a, b) => a.source.localeCompare(b.source));
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totals,
+    agents: agentRows,
+    sources,
+    recent: state.recent.slice(0, 50),
+    alerts: state.alerts.slice(0, 20),
+    workflowProgress: agentRows.map((row) => roleProgressRow(state.byAgent, row.agentId))
+  };
+}


### PR DESCRIPTION
## Summary
- `roleProgressRow`, `buildSnapshot`을 `server-logic.js`로 분리하여 순수 함수로 export
- `state`를 파라미터로 받도록 변경하여 테스트 가능성(testability) 확보
- `__tests__/server-logic.test.js`에 7개 단위 테스트 추가 (TDD Red→Green)

## Changes
- `server-logic.js` (신규): `roleProgressRow(byAgent, roleId)`, `buildSnapshot(state)` export
- `server.js`: 기존 함수 제거 후 `server-logic.js` import, `buildSnapshot(state)` 호출
- `__tests__/server-logic.test.js` (신규): roleProgressRow 4개 + buildSnapshot 3개 테스트
- `package.json`: `check`에 `server-logic.js` 추가, `test:server` 스크립트 추가

## Related Issue
Closes #8

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] `node --test '__tests__/server-logic.test.js'` — 7/7 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)