### PR TITLE
feat(ui): 대시보드에 비용(Cost USD) 카드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:js": "node --test 'public/__tests__/**/*.test.js'",
     "test:collector": "node --test scripts/__tests__/claude-local-collector.test.js",
     "test:server": "node --test '__tests__/server-logic.test.js'",
-    "check": "node --check server.js && node --check server-logic.js && node --check simulator.js && node --check scripts/frontend-load-test.js && node --check scripts/claude-local-collector.js && node --check scripts/__tests__/claude-local-collector.test.js && node --check public/app.js && node --check public/lib/workflow.js && node --check desktop/main.js"
+    "check": "node --check server.js && node --check server-logic.js && node --check simulator.js && node --check scripts/frontend-load-test.js && node --check scripts/claude-local-collector.js && node --check scripts/__tests__/claude-local-collector.test.js && node --check public/app.js && node --check public/lib/workflow.js && node --check public/lib/cards.js && node --check public/__tests__/cards.test.js && node --check desktop/main.js"
   },
   "devDependencies": {
     "electron": "^35.0.0"

--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCardData } from '../lib/cards.js';
+
+const numberFmt = new Intl.NumberFormat('ko-KR');
+
+describe('buildCardData', () => {
+  it('includes Cost (USD) card with 4 decimal places', () => {
+    const totals = {
+      agents: 2,
+      total: 10,
+      tokenTotal: 500,
+      ok: 7,
+      warning: 2,
+      error: 1,
+      costTotalUsd: 0.0523
+    };
+    const cards = buildCardData(totals, numberFmt);
+    const costCard = cards.find(([label]) => label === 'Cost (USD)');
+    assert.ok(costCard, 'Cost (USD) card should exist');
+    assert.equal(costCard[1], '0.0523');
+  });
+
+  it('shows 0.0000 when costTotalUsd is missing', () => {
+    const totals = { agents: 1, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const costCard = cards.find(([label]) => label === 'Cost (USD)');
+    assert.ok(costCard, 'Cost (USD) card should exist');
+    assert.equal(costCard[1], '0.0000');
+  });
+
+  it('shows 0.0000 when costTotalUsd is null', () => {
+    const totals = { agents: 0, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: null };
+    const cards = buildCardData(totals, numberFmt);
+    const costCard = cards.find(([label]) => label === 'Cost (USD)');
+    assert.equal(costCard[1], '0.0000');
+  });
+
+  it('returns 7 cards total', () => {
+    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
+    const cards = buildCardData(totals, numberFmt);
+    assert.equal(cards.length, 7);
+  });
+
+  it('formats non-cost values with numberFmt', () => {
+    const totals = { agents: 1000, total: 5000, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    assert.equal(cards[0][1], '1,000');
+    assert.equal(cards[1][1], '5,000');
+  });
+
+  it('shows 0 for undefined numeric fields', () => {
+    const totals = {};
+    const cards = buildCardData(totals, numberFmt);
+    assert.equal(cards[0][1], '0');   // Agents
+    assert.equal(cards[3][1], '0');   // OK
+    assert.equal(cards[6][1], '0.0000'); // Cost (USD)
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,5 @@
 import { recalcWorkflow } from './lib/workflow.js';
+import { buildCardData } from './lib/cards.js';
 
 const cardsRoot = document.getElementById('cards');
 const throughputChart = document.getElementById('throughputChart');
@@ -62,19 +63,12 @@ function stopPolling() {
 }
 
 function renderCards(totals) {
-  const cards = [
-    ['Agents', totals.agents],
-    ['Total Events', totals.total],
-    ['Total Tokens', totals.tokenTotal || 0],
-    ['OK', totals.ok],
-    ['Warning', totals.warning],
-    ['Error', totals.error]
-  ];
+  const cards = buildCardData(totals, numberFmt);
 
   cardsRoot.innerHTML = cards
     .map(
       ([label, value]) =>
-        `<article class="card"><div class="label">${label}</div><div class="value">${numberFmt.format(value || 0)}</div></article>`
+        `<article class="card"><div class="label">${label}</div><div class="value">${value}</div></article>`
     )
     .join('');
 }

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,0 +1,11 @@
+export function buildCardData(totals, numberFmt) {
+  return [
+    ['Agents', numberFmt.format(totals.agents || 0)],
+    ['Total Events', numberFmt.format(totals.total || 0)],
+    ['Total Tokens', numberFmt.format(totals.tokenTotal || 0)],
+    ['OK', numberFmt.format(totals.ok || 0)],
+    ['Warning', numberFmt.format(totals.warning || 0)],
+    ['Error', numberFmt.format(totals.error || 0)],
+    ['Cost (USD)', Number(totals.costTotalUsd || 0).toFixed(4)]
+  ];
+}


### PR DESCRIPTION
## Summary
- `public/lib/cards.js`에 `buildCardData()` 함수를 분리하여 카드 데이터 생성 로직 모듈화
- `renderCards()`가 `buildCardData()`를 사용하도록 수정하고, `Cost (USD)` 카드 추가
- `totals.costTotalUsd` 값을 소수점 4자리로 표시

## Changes
- `public/lib/cards.js` (신규): 7개 카드 데이터 생성 로직, Cost (USD) 카드 포함
- `public/__tests__/cards.test.js` (신규): 6개 테스트 (정상값, null, undefined, 소수점 포맷 등)
- `public/app.js`: `renderCards()`를 `buildCardData()` 위임 방식으로 단순화
- `package.json`: `check` 스크립트에 신규 파일 추가

## Related Issue
Closes #12

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] 대시보드에서 `Cost (USD)` 카드 소수점 4자리 표시 확인
- [ ] `costTotalUsd`가 없을 때 `0.0000` 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)