### PR TITLE
docs(docs): 프로젝트 메타데이터 및 문서를 Claude 기준으로 업데이트

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Codex Pulse
+# Contributing to Claude Monitor
 
-Thank you for your interest in contributing to Codex Pulse!
+Thank you for your interest in contributing to Claude Monitor!
 
 ## Prerequisites
 
@@ -12,8 +12,8 @@ Thank you for your interest in contributing to Codex Pulse!
 
 ```bash
 # Clone the repository
-git clone https://github.com/<owner>/codex-pulse.git
-cd codex-pulse
+git clone https://github.com/<owner>/claude-code-monitor.git
+cd claude-code-monitor
 
 # Install Node dependencies
 npm install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "codex_pulse"
+name = "claude_code_monitor"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "codex_pulse"
+name = "claude_code_monitor"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Codex Pulse
+# Claude Monitor
 
-[![GitHub release](https://img.shields.io/github/v/release/7zrv/codex-pulse)](https://github.com/7zrv/codex-pulse/releases)
-[![License](https://img.shields.io/github/license/7zrv/codex-pulse)](https://github.com/7zrv/codex-pulse/blob/main/LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/7zrv/claude-code-monitor)](https://github.com/7zrv/claude-code-monitor/releases)
+[![License](https://img.shields.io/github/license/7zrv/claude-code-monitor)](https://github.com/7zrv/claude-code-monitor/blob/main/LICENSE)
 [![Rust](https://img.shields.io/badge/Rust-1.56%2B-orange?logo=rust)](https://www.rust-lang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-green?logo=node.js)](https://nodejs.org/)
 
-Codex 로컬 앱 사용 환경을 기준으로, Rust 백엔드 + 기존 정적 UI(`public/*`)로 마이그레이션한 모니터입니다.
+Claude Code 에이전트의 실시간 모니터링 대시보드. Rust 백엔드 + 정적 UI(`public/*`) 구조.
 
 ## 핵심 기능
 - `POST /api/events` 이벤트 수집
 - `GET /api/events` 스냅샷
 - `GET /api/stream` SSE 스트림
 - `GET /api/alerts` 경고/오류 알림
-- `~/.codex/history.jsonl`, `~/.codex/log/codex-tui.log` 자동 수집(내장)
+- `~/.claude/history.jsonl`, `~/.claude/projects/` 자동 수집(내장)
 - 대시보드: agent/workflow/source/alerts/최근 이벤트
 - 토큰 지표: 총 토큰(`totals.tokenTotal`) + 에이전트별 토큰(`agents[].tokenTotal`)
 
@@ -26,9 +26,9 @@ cargo run --release
 환경변수:
 - `PORT` (기본: `5050`)
 - `HOST` (기본: `127.0.0.1`)
-- `CODEX_HOME` (기본: `~/.codex`)
-- `CODEX_POLL_MS` (기본: `2500`)
-- `CODEX_BACKFILL_LINES` (기본: `25`)
+- `CLAUDE_HOME` (기본: `~/.claude`)
+- `CLAUDE_POLL_MS` (기본: `2500`)
+- `CLAUDE_BACKFILL_LINES` (기본: `25`)
 - `MONITOR_API_KEY` (설정 시 `POST /api/events`에 `x-api-key` 필수)
 - `PUBLIC_DIR` (기본: `public`) — 정적 파일 디렉토리 경로
 - `HTTP_READ_TIMEOUT_SEC` (기본: `5`)

--- a/migration/improvement-plan-2026-02-26.md
+++ b/migration/improvement-plan-2026-02-26.md
@@ -151,7 +151,7 @@ curl -s http://localhost:5050/api/events | grep -o '&lt;img'  # 기대: 매치 �
 | 항목 | 내용 |
 |------|------|
 | 심각도 | **Critical** (기능 장애) |
-| 파일 | `scripts/codex-local-collector.js:245` |
+| 파일 | `scripts/claude-local-collector.js:245` |
 | 수정 내역 | `.split('\\n')` (리터럴 백슬래시+n) → `.split('\n')` (개행 문자)으로 수정 |
 | 담당 | backend |
 
@@ -159,7 +159,7 @@ curl -s http://localhost:5050/api/events | grep -o '&lt;img'  # 기대: 매치 �
 
 **수정:**
 ```js
-// scripts/codex-local-collector.js:245
+// scripts/claude-local-collector.js:245
 // Before
 .split('\\n')
 
@@ -168,7 +168,7 @@ curl -s http://localhost:5050/api/events | grep -o '&lt;img'  # 기대: 매치 �
 ```
 
 **수락 기준:**
-- `npm run collect:codex` 실행 시 기존 history.jsonl에서 최근 N줄이 정상 backfill됨
+- `npm run collect:claude` 실행 시 기존 history.jsonl에서 최근 N줄이 정상 backfill됨
 
 ---
 
@@ -398,7 +398,7 @@ function stopPolling() {
 
 | 항목 | 내용 |
 |------|------|
-| 파일 | `server.js`, `scripts/codex-local-collector.js` |
+| 파일 | `server.js`, `scripts/claude-local-collector.js` |
 | 현상 | Rust 서버와 동일한 로직이 Node.js에 중복 존재. 동시 실행 시 이벤트 중복 수집. Node 서버는 token tracking 미구현으로 기능 패리티 부족 |
 | 수정 방향 | Node 서버와 collector를 `legacy/` 디렉터리로 이동. package.json에서 `start` 스크립트를 Rust로 변경 |
 | 담당 | lead |
@@ -407,7 +407,7 @@ function stopPolling() {
 ```
 legacy/
   server.js          ← 기존 server.js
-  collector.js       ← 기존 scripts/codex-local-collector.js
+  collector.js       ← 기존 scripts/claude-local-collector.js
 ```
 
 ```json
@@ -823,7 +823,7 @@ Phase 완료 판정은 아래 기준을 모두 충족해야 한다:
   curl -s -o /dev/null -w '%{http_code}' 'http://localhost:5050/index.html'          # == 200
   ```
 - XSS 페이로드 POST 후 대시보드에서 스크립트 미실행 (수동 확인)
-- `npm run collect:codex`에서 backfill 정상 동작 확인
+- `npm run collect:claude`에서 backfill 정상 동작 확인
 - Node 서버 `MONITOR_API_KEY` 검증 동작 확인
 
 ### Phase 1 (1~2주)

--- a/migration/improvement-review-2026-02-25.md
+++ b/migration/improvement-review-2026-02-25.md
@@ -1,7 +1,7 @@
 # Improvement Review (2026-02-25)
 
 ## 범위
-- 프로젝트: `Codex Pulse`
+- 프로젝트: `Claude Monitor`
 - 기준일: 2026-02-25
 - 역할: lead, designer, frontend, backend
 
@@ -53,7 +53,7 @@
 ## Backend (기능 개발 에이전트)
 ### 발견된 개선점
 1. 현재 `std::net` 수동 HTTP 파서로 엣지 케이스(대용량/헤더 변형) 대응 한계.
-2. 수집이 폴링 기반(`CODEX_POLL_MS`)이라 완전 실시간이 아님.
+2. 수집이 폴링 기반(`CLAUDE_POLL_MS`)이라 완전 실시간이 아님.
 3. 영속 저장소 부재로 프로세스 재시작 시 히스토리 손실.
 4. 인증/인가가 없어 로컬 외 노출 시 보안 위험.
 

--- a/migration/ops-runbook.md
+++ b/migration/ops-runbook.md
@@ -11,8 +11,8 @@
 
 ## Incident: No Event Updates
 1. `/api/health` 확인
-2. `CODEX_HOME` 경로 확인
-3. `.codex/history.jsonl`, `.codex/log/codex-tui.log` 갱신 여부 확인
+2. `CLAUDE_HOME` 경로 확인
+3. `.claude/history.jsonl`, `.claude/projects/` 갱신 여부 확인
 4. 앱 재기동
 
 ## Incident: Unauthorized POST

--- a/migration/progress.md
+++ b/migration/progress.md
@@ -45,7 +45,7 @@
 - [x] Rust 프로젝트 생성 (`Cargo.toml`, `src/main.rs`)
 - [x] API 구현 (`/api/health`, `/api/events`, `/api/alerts`, `/api/stream`)
 - [x] SSE 브로드캐스트 구현
-- [x] `.codex/history.jsonl`, `.codex/log/codex-tui.log` 수집 내장
+- [x] `.claude/history.jsonl`, `.claude/projects/` 수집 내장
 - [x] source/agent/workflow/alerts 집계 구현
 - [x] 파일감시/영속화/보안 개선 과제 도출
 - [x] API Key 기반 입력 보호(`MONITOR_API_KEY`) 착수

--- a/migration/release-checklist.md
+++ b/migration/release-checklist.md
@@ -10,7 +10,7 @@
 - [ ] `/api/health` 정상
 - [x] `/api/events` 스냅샷 정상
 - [ ] `/api/stream` SSE 연결/재연결 정상
-- [x] `.codex` 수집 이벤트가 대시보드에 반영됨
+- [x] `.claude` 수집 이벤트가 대시보드에 반영됨
 
 ## Quality Gate
 - [x] 2색 제한 준수 (`#E26D5C`, `#F6EDE3`)

--- a/migration/role-plan.md
+++ b/migration/role-plan.md
@@ -2,10 +2,10 @@
 
 ## 총괄 에이전트 (lead)
 - 목표: Node/Electron 중심 구조에서 Rust 중심 구조로 이전
-- 범위: 이벤트 수집, 상태 집계, SSE, 정적 대시보드 서빙, Codex 로컬 로그 수집
+- 범위: 이벤트 수집, 상태 집계, SSE, 정적 대시보드 서빙, Claude 로컬 로그 수집
 - 수락 기준:
   - Rust 바이너리 1개로 `/api/health`, `/api/events`, `/api/stream`, `/api/alerts` 제공
-  - `~/.codex` 입력으로 이벤트가 수집됨
+  - `~/.claude` 입력으로 이벤트가 수집됨
   - 기존 UI(`public/*`)가 그대로 동작
 
 ## 디자이너 에이전트 (designer)
@@ -25,7 +25,7 @@
 - 작업:
   - Rust `std` 기반 HTTP 서버 구현
   - SSE 브로드캐스트, 상태 집계, 알림 집계
-  - `~/.codex/history.jsonl`, `~/.codex/log/codex-tui.log` 폴링 수집기 내장
+  - `~/.claude/history.jsonl`, `~/.claude/projects/` 폴링 수집기 내장
 - 검증:
   - `cargo build` 성공
   - 스모크 테스트로 이벤트 적재 확인

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "codex-pulse",
+  "name": "claude-code-monitor",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-pulse",
+      "name": "claude-code-monitor",
       "version": "0.1.0",
       "devDependencies": {
         "electron": "^35.0.0"


### PR DESCRIPTION
## Summary
- `Cargo.toml` 패키지명 `codex_pulse` → `claude_code_monitor` 변경
- `README.md` 제목·배지·설명·환경변수(`CODEX_*` → `CLAUDE_*`)·경로(`~/.codex` → `~/.claude`) 업데이트
- `CONTRIBUTING.md` 및 `migration/` 파일 전반의 Codex 브랜딩 제거

## Changes
- `Cargo.toml` / `Cargo.lock`: 패키지명 변경
- `README.md`: 제목, 배지 URL, 설명, 수집 경로, 환경변수 전면 업데이트
- `CONTRIBUTING.md`: 프로젝트명 및 clone URL 수정
- `migration/ops-runbook.md`: `CODEX_HOME` → `CLAUDE_HOME`, 경로 수정
- `migration/improvement-review-2026-02-25.md`: 프로젝트명·환경변수명 수정
- `migration/improvement-plan-2026-02-26.md`: 스크립트명·npm 명령어 수정
- `migration/release-checklist.md` / `role-plan.md` / `progress.md`: 경로 수정
- `package-lock.json`: npm install로 패키지명 자동 갱신

## Related Issue
Closes #15

## Test Plan
- [x] `cargo build` pass
- [x] `npm run check` pass
- [x] Codex 잔여 참조 없음 (`grep` 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)