### PR TITLE
feat(ui): 시맨틱 색상 시스템 및 차트 다색 팔레트 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:js": "node --test 'public/__tests__/**/*.test.js'",
     "test:collector": "node --test scripts/__tests__/claude-local-collector.test.js",
     "test:server": "node --test '__tests__/server-logic.test.js'",
-    "check": "node --check server.js && node --check server-logic.js && node --check simulator.js && node --check scripts/frontend-load-test.js && node --check scripts/claude-local-collector.js && node --check scripts/__tests__/claude-local-collector.test.js && node --check scripts/__tests__/simulator.test.js && node --check scripts/__tests__/frontend-load-test.test.js && node --check public/app.js && node --check public/lib/workflow.js && node --check public/lib/cards.js && node --check public/__tests__/cards.test.js && node --check desktop/main.js"
+    "check": "node --check server.js && node --check server-logic.js && node --check simulator.js && node --check scripts/frontend-load-test.js && node --check scripts/claude-local-collector.js && node --check scripts/__tests__/claude-local-collector.test.js && node --check scripts/__tests__/simulator.test.js && node --check scripts/__tests__/frontend-load-test.test.js && node --check public/app.js && node --check public/lib/workflow.js && node --check public/lib/cards.js && node --check public/lib/palette.js && node --check public/__tests__/cards.test.js && node --check public/__tests__/palette.test.js && node --check desktop/main.js"
   },
   "devDependencies": {
     "electron": "^35.0.0"

--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -56,4 +56,35 @@ describe('buildCardData', () => {
     assert.equal(cards[3][1], '0');   // OK
     assert.equal(cards[6][1], '0.0000'); // Cost (USD)
   });
+
+  it('assigns ok type to OK card', () => {
+    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 1, warning: 0, error: 0, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const okCard = cards.find(([label]) => label === 'OK');
+    assert.equal(okCard[2], 'ok');
+  });
+
+  it('assigns warning type to Warning card', () => {
+    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 1, error: 0, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const warningCard = cards.find(([label]) => label === 'Warning');
+    assert.equal(warningCard[2], 'warning');
+  });
+
+  it('assigns error type to Error card', () => {
+    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 1, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const errorCard = cards.find(([label]) => label === 'Error');
+    assert.equal(errorCard[2], 'error');
+  });
+
+  it('assigns neutral type to non-status cards', () => {
+    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
+    const cards = buildCardData(totals, numberFmt);
+    const neutralLabels = ['Agents', 'Total Events', 'Total Tokens', 'Cost (USD)'];
+    for (const label of neutralLabels) {
+      const card = cards.find(([l]) => l === label);
+      assert.equal(card[2], 'neutral', `${label} should have neutral type`);
+    }
+  });
 });

--- a/public/__tests__/palette.test.js
+++ b/public/__tests__/palette.test.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { CHART_PALETTE, colorForIndex } from '../lib/palette.js';
+
+describe('CHART_PALETTE', () => {
+  it('has exactly 8 colors', () => {
+    assert.equal(CHART_PALETTE.length, 8);
+  });
+
+  it('contains only valid hex color codes', () => {
+    const hexPattern = /^#[0-9A-Fa-f]{6}$/;
+    for (const color of CHART_PALETTE) {
+      assert.match(color, hexPattern, `${color} is not a valid hex code`);
+    }
+  });
+
+  it('contains all unique colors', () => {
+    const unique = new Set(CHART_PALETTE);
+    assert.equal(unique.size, CHART_PALETTE.length);
+  });
+});
+
+describe('colorForIndex', () => {
+  it('returns the first color for index 0', () => {
+    assert.equal(colorForIndex(0), CHART_PALETTE[0]);
+  });
+
+  it('returns the last color for index 7', () => {
+    assert.equal(colorForIndex(7), CHART_PALETTE[7]);
+  });
+
+  it('wraps around when index exceeds palette length', () => {
+    assert.equal(colorForIndex(8), CHART_PALETTE[0]);
+    assert.equal(colorForIndex(10), CHART_PALETTE[2]);
+    assert.equal(colorForIndex(16), CHART_PALETTE[0]);
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,6 @@
 import { recalcWorkflow } from './lib/workflow.js';
 import { buildCardData } from './lib/cards.js';
+import { colorForIndex } from './lib/palette.js';
 
 const cardsRoot = document.getElementById('cards');
 const throughputChart = document.getElementById('throughputChart');
@@ -67,8 +68,8 @@ function renderCards(totals) {
 
   cardsRoot.innerHTML = cards
     .map(
-      ([label, value]) =>
-        `<article class="card"><div class="label">${label}</div><div class="value">${value}</div></article>`
+      ([label, value, type]) =>
+        `<article class="card card--${type}"><div class="label">${label}</div><div class="value">${value}</div></article>`
     )
     .join('');
 }
@@ -325,15 +326,13 @@ function renderTokenTrendChart(events = []) {
   const max = Math.max(1, ...Object.values(seriesByAgent).flat());
   const midY = height.top + (height.bottom - height.top) / 2;
   const slotWidth = (width.right - width.left) / (buckets.length - 1 || 1);
-  const dashPatterns = ['0', '6 3', '2 2', '10 4', '1 3'];
   const lineWidths = [2.6, 2.2, 2, 1.8, 1.6];
 
   const lineSvg = agents
     .map((agent, idx) => {
       const d = pathForSeries(seriesByAgent[agent], width, height, max);
-      const dash = dashPatterns[idx % dashPatterns.length];
       const strokeWidth = lineWidths[idx % lineWidths.length];
-      return `<path d="${d}" fill="none" stroke="rgb(226 109 92 / 82%)" stroke-width="${strokeWidth}" stroke-dasharray="${dash}" />`;
+      return `<path d="${d}" fill="none" stroke="${colorForIndex(idx)}" stroke-width="${strokeWidth}" />`;
     })
     .join('');
 
@@ -343,7 +342,7 @@ function renderTokenTrendChart(events = []) {
       const last = values[values.length - 1] || 0;
       const x = width.right - 2;
       const y = height.bottom - (last / max) * (height.bottom - height.top);
-      return `<text x="${x}" y="${Math.max(height.top + 8, y - idx * 2).toFixed(2)}" text-anchor="end" font-size="10" fill="rgb(226 109 92 / 90%)">${escapeHtml(agent)}</text>`;
+      return `<text x="${x}" y="${Math.max(height.top + 8, y - idx * 2).toFixed(2)}" text-anchor="end" font-size="10" fill="${colorForIndex(idx)}">${escapeHtml(agent)}</text>`;
     })
     .join('');
 
@@ -369,13 +368,13 @@ function renderTokenTrendChart(events = []) {
 
   tokenTrendLegend.innerHTML = agents
     .map((agent, idx) => {
-      const dash = dashPatterns[idx % dashPatterns.length];
       const latest = seriesByAgent[agent][seriesByAgent[agent].length - 1] || 0;
       const strokeWidth = lineWidths[idx % lineWidths.length];
+      const color = colorForIndex(idx);
       return `
-        <span class="legend-item" title="dash:${dash}">
+        <span class="legend-item">
           <svg class="legend-line" viewBox="0 0 22 8" preserveAspectRatio="none">
-            <line x1="0" y1="4" x2="22" y2="4" stroke="rgb(226 109 92 / 90%)" stroke-width="${strokeWidth}" stroke-dasharray="${dash}" />
+            <line x1="0" y1="4" x2="22" y2="4" stroke="${color}" stroke-width="${strokeWidth}" />
           </svg>
           <strong>${escapeHtml(agent)}</strong>
           <em>${numberFmt.format(latest)} tok/min</em>

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,11 +1,11 @@
 export function buildCardData(totals, numberFmt) {
   return [
-    ['Agents', numberFmt.format(totals.agents || 0)],
-    ['Total Events', numberFmt.format(totals.total || 0)],
-    ['Total Tokens', numberFmt.format(totals.tokenTotal || 0)],
-    ['OK', numberFmt.format(totals.ok || 0)],
-    ['Warning', numberFmt.format(totals.warning || 0)],
-    ['Error', numberFmt.format(totals.error || 0)],
-    ['Cost (USD)', Number(totals.costTotalUsd || 0).toFixed(4)]
+    ['Agents', numberFmt.format(totals.agents || 0), 'neutral'],
+    ['Total Events', numberFmt.format(totals.total || 0), 'neutral'],
+    ['Total Tokens', numberFmt.format(totals.tokenTotal || 0), 'neutral'],
+    ['OK', numberFmt.format(totals.ok || 0), 'ok'],
+    ['Warning', numberFmt.format(totals.warning || 0), 'warning'],
+    ['Error', numberFmt.format(totals.error || 0), 'error'],
+    ['Cost (USD)', Number(totals.costTotalUsd || 0).toFixed(4), 'neutral']
   ];
 }

--- a/public/lib/palette.js
+++ b/public/lib/palette.js
@@ -1,0 +1,8 @@
+export const CHART_PALETTE = [
+  '#4E79A7', '#F28E2B', '#E15759', '#76B7B2',
+  '#59A14F', '#EDC948', '#B07AA1', '#FF9DA7'
+];
+
+export function colorForIndex(idx) {
+  return CHART_PALETTE[idx % CHART_PALETTE.length];
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -2,6 +2,24 @@
   --warm: #E26D5C;
   --warm-text: #B84A3A;
   --paper: #F6EDE3;
+
+  --color-ok: #2E8B57;
+  --color-warning: #D4850A;
+  --color-error: #C93A3A;
+
+  --chart-1: #4E79A7;
+  --chart-2: #F28E2B;
+  --chart-3: #E15759;
+  --chart-4: #76B7B2;
+  --chart-5: #59A14F;
+  --chart-6: #EDC948;
+  --chart-7: #B07AA1;
+  --chart-8: #FF9DA7;
+
+  --surface: rgb(246 237 227 / 86%);
+  --border: rgb(226 109 92 / 40%);
+  --border-subtle: rgb(226 109 92 / 24%);
+  --border-medium: rgb(226 109 92 / 30%);
 }
 
 * {
@@ -65,14 +83,38 @@ main {
 
 .card,
 .panel {
-  border: 1px solid rgb(226 109 92 / 40%);
+  border: 1px solid var(--border);
   border-radius: 14px;
-  background: rgb(246 237 227 / 86%);
+  background: var(--surface);
   backdrop-filter: blur(3px);
 }
 
 .card {
   padding: 14px;
+}
+
+.card--ok {
+  border-color: var(--color-ok);
+}
+
+.card--ok .value {
+  color: var(--color-ok);
+}
+
+.card--warning {
+  border-color: var(--color-warning);
+}
+
+.card--warning .value {
+  color: var(--color-warning);
+}
+
+.card--error {
+  border-color: var(--color-error);
+}
+
+.card--error .value {
+  color: var(--color-error);
 }
 
 .card .label {
@@ -107,7 +149,7 @@ main {
 }
 
 select {
-  border: 1px solid rgb(226 109 92 / 45%);
+  border: 1px solid var(--border);
   background: var(--paper);
   color: var(--warm-text);
   border-radius: 8px;
@@ -115,7 +157,7 @@ select {
 }
 
 input[type='search'] {
-  border: 1px solid rgb(226 109 92 / 45%);
+  border: 1px solid var(--border);
   background: var(--paper);
   color: var(--warm-text);
   border-radius: 8px;
@@ -136,7 +178,7 @@ input[type='search'] {
 }
 
 .workflow-item {
-  border: 1px solid rgb(226 109 92 / 30%);
+  border: 1px solid var(--border-medium);
   border-radius: 10px;
   padding: 10px;
   display: grid;
@@ -152,7 +194,7 @@ input[type='search'] {
 
 .chart-card {
   position: relative;
-  border: 1px solid rgb(226 109 92 / 30%);
+  border: 1px solid var(--border-medium);
   border-radius: 10px;
   padding: 10px;
   background: rgb(246 237 227 / 70%);
@@ -166,7 +208,7 @@ input[type='search'] {
 .throughput-chart {
   width: 100%;
   height: 200px;
-  border: 1px solid rgb(226 109 92 / 24%);
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: rgb(246 237 227 / 82%);
 }
@@ -174,7 +216,7 @@ input[type='search'] {
 .token-trend-chart {
   width: 100%;
   height: 200px;
-  border: 1px solid rgb(226 109 92 / 24%);
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: rgb(246 237 227 / 82%);
 }
@@ -192,7 +234,7 @@ input[type='search'] {
   align-items: center;
   gap: 6px;
   padding: 2px 6px;
-  border: 1px solid rgb(226 109 92 / 40%);
+  border: 1px solid var(--border);
   border-radius: 999px;
 }
 
@@ -208,7 +250,7 @@ input[type='search'] {
   z-index: 3;
   padding: 4px 8px;
   font-size: 11px;
-  border: 1px solid rgb(226 109 92 / 50%);
+  border: 1px solid var(--border);
   border-radius: 6px;
   background: rgb(246 237 227 / 95%);
   pointer-events: none;
@@ -224,7 +266,7 @@ th,
 td {
   text-align: left;
   padding: 10px 8px;
-  border-bottom: 1px solid rgb(226 109 92 / 24%);
+  border-bottom: 1px solid var(--border-subtle);
   white-space: nowrap;
 }
 
@@ -246,7 +288,7 @@ th {
   gap: 8px;
   padding: 9px;
   border-radius: 10px;
-  border: 1px solid rgb(226 109 92 / 30%);
+  border: 1px solid var(--border-medium);
   background: rgb(246 237 227 / 78%);
   font-size: 13px;
   align-items: center;
@@ -256,7 +298,7 @@ th {
   font-size: 11px;
   padding: 2px 8px;
   border-radius: 999px;
-  border: 1px solid rgb(226 109 92 / 50%);
+  border: 1px solid var(--border);
 }
 
 .status-pill {
@@ -265,32 +307,37 @@ th {
   letter-spacing: 0.08em;
   padding: 3px 8px;
   border-radius: 999px;
-  border: 1px solid rgb(226 109 92 / 60%);
+  border: 1px solid var(--border);
 }
 
 .status-pill[data-status='warning'] {
-  border-style: dashed;
+  border-color: var(--color-warning);
+  color: var(--color-warning);
 }
 
 .status-pill[data-status='error'] {
   border-width: 2px;
-  border-style: double;
+  border-color: var(--color-error);
+  color: var(--color-error);
   font-weight: 700;
 }
 
 .status-pill[data-status='blocked'] {
   border-width: 2px;
-  border-style: double;
+  border-color: var(--color-error);
+  color: var(--color-error);
   font-weight: 700;
 }
 
 .status-pill[data-status='running'] {
   border-width: 2px;
-  border-style: solid;
+  border-color: var(--color-ok);
+  color: var(--color-ok);
 }
 
 .status-pill[data-status='at-risk'] {
-  border-style: dashed;
+  border-color: var(--color-warning);
+  color: var(--color-warning);
   font-weight: 600;
 }
 
@@ -300,16 +347,19 @@ th {
 }
 
 .status-pill[data-status='connected'] {
-  border-style: solid;
+  border-color: var(--color-ok);
+  color: var(--color-ok);
 }
 
 .status-pill[data-status='reconnecting'] {
-  border-style: dashed;
+  border-color: var(--color-warning);
+  color: var(--color-warning);
 }
 
 .status-pill[data-status='offline'] {
-  border-style: dotted;
   border-width: 2px;
+  border-color: var(--color-error);
+  color: var(--color-error);
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
## Summary
- CSS 시맨틱 색상 변수 도입(`--color-ok`, `--color-warning`, `--color-error`, `--chart-1~8`)으로 단일 코랄 색상 의존도 제거
- KPI 카드에 `card--ok/warning/error/neutral` 클래스 적용, status-pill을 border-style → 색상 구분으로 전환
- 토큰 트렌드 차트에 에이전트별 고유 8색 팔레트(`palette.js`) 적용

## Changes
- `public/lib/palette.js` (신규): `CHART_PALETTE` 8색 상수 + `colorForIndex` 헬퍼
- `public/__tests__/palette.test.js` (신규): palette 모듈 테스트 6개
- `public/lib/cards.js`: `buildCardData` 반환값 `[label, value]` → `[label, value, type]` 3-튜플 확장
- `public/__tests__/cards.test.js`: 시맨틱 타입 검증 테스트 4개 추가 (총 10개)
- `public/styles.css`: CSS 변수 시스템 도입, 카드/status-pill 시맨틱 색상 적용
- `public/app.js`: palette import, 차트·범례·카드 렌더링에 색상 적용
- `package.json`: `check` 스크립트에 신규 파일 추가

## Related Issue
Closes #49

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)