### PR TITLE
feat(ui): 인터랙션 피드백 및 반응형 브레이크포인트 확장

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -20,6 +20,9 @@
   --border: rgb(226 109 92 / 40%);
   --border-subtle: rgb(226 109 92 / 24%);
   --border-medium: rgb(226 109 92 / 30%);
+
+  --hover-overlay: rgb(226 109 92 / 8%);
+  --focus-ring: rgb(226 109 92 / 60%);
 }
 
 * {
@@ -91,6 +94,12 @@ main {
 
 .card {
   padding: 14px;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgb(226 109 92 / 16%);
 }
 
 .card--ok {
@@ -165,6 +174,22 @@ input[type='search'] {
   min-width: 180px;
 }
 
+select,
+input[type='search'] {
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+select:hover,
+input[type='search']:hover {
+  border-color: var(--warm);
+}
+
+select:focus,
+input[type='search']:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
 #eventMeta {
   display: block;
   margin-bottom: 8px;
@@ -184,6 +209,12 @@ input[type='search'] {
   display: grid;
   gap: 4px;
   background: rgb(246 237 227 / 70%);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.workflow-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 12px rgb(226 109 92 / 12%);
 }
 
 .charts-grid {
@@ -275,6 +306,10 @@ th {
   letter-spacing: 0.02em;
 }
 
+tbody tr:hover td {
+  background: var(--hover-overlay);
+}
+
 .events {
   max-height: 320px;
   overflow-y: auto;
@@ -292,6 +327,12 @@ th {
   background: rgb(246 237 227 / 78%);
   font-size: 13px;
   align-items: center;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.event:hover {
+  background: var(--hover-overlay);
+  border-color: var(--border);
 }
 
 .badge {
@@ -362,7 +403,18 @@ th {
   color: var(--color-error);
 }
 
-@media (max-width: 760px) {
+@media (max-width: 1080px) {
+  main,
+  .header {
+    width: 96vw;
+  }
+
+  .charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
   .event {
     grid-template-columns: 1fr;
     gap: 4px;
@@ -372,5 +424,28 @@ th {
   td {
     font-size: 13px;
     padding: 8px 6px;
+  }
+
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  h1 {
+    font-size: 1.3rem;
+  }
+
+  .panel {
+    padding: 8px;
+  }
+
+  input[type='search'] {
+    width: 100%;
+    min-width: unset;
   }
 }


### PR DESCRIPTION
## Summary
- 카드, 테이블 행, select/input, 이벤트, 워크플로우 항목에 hover/focus 피드백 스타일 추가
- 반응형 브레이크포인트를 760px 단일에서 1080px / 768px / 480px 3단계로 교체
- CSS 변수 `--hover-overlay`, `--focus-ring` 추가

## Changes
- `:root`에 `--hover-overlay: rgb(226 109 92 / 8%)`, `--focus-ring: rgb(226 109 92 / 60%)` 추가
- `.card:hover` — `translateY(-2px)` + 그림자 효과
- `tbody tr:hover td` — 배경 하이라이트
- `select`, `input[type='search']` hover/focus 스타일 그룹화
- `.event:hover` — 배경/테두리 변화
- `.workflow-item:hover` — `translateY(-1px)` + 그림자
- `@media (max-width: 1080px)` — 차트 1열, 컨테이너 96vw
- `@media (max-width: 768px)` — 이벤트 1열, 테이블 축소, 카드 minmax 140px
- `@media (max-width: 480px)` — 카드 2열, 제목 축소, 패널 패딩, 검색 전체 너비

## Related Issue
Closes #50

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] 1080px / 768px / 480px 뷰포트별 레이아웃 확인
- [ ] 카드·이벤트·워크플로우·테이블 행 hover 효과 확인
- [ ] select/input hover·focus 스타일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)