### PR TITLE
feat(ui): 다크 모드 지원 추가

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -27,6 +27,10 @@ let renderQueued = false;
 const storageKey = 'agent_monitor_event_filters_v1';
 let pollTimer = null;
 
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replaceAll('&', '&amp;')
@@ -239,6 +243,14 @@ function renderThroughputChart(events = []) {
   const slot = (right - left) / buckets.length;
   const midY = top + chartHeight / 2;
 
+  const barColor = cssVar('--chart-bar');
+  const axisColor = cssVar('--chart-axis');
+  const axisSecondary = cssVar('--chart-axis-secondary');
+  const axisMid = cssVar('--chart-axis-mid');
+  const labelColor = cssVar('--chart-label');
+  const sublabelColor = cssVar('--chart-sublabel');
+  const timescaleColor = cssVar('--chart-timescale');
+
   const bars = buckets
     .map((b, idx) => {
       const barH = Math.max(1, (b.events / max) * chartHeight);
@@ -246,25 +258,25 @@ function renderThroughputChart(events = []) {
       const y = bottom - barH;
       const w = Math.max(1, slot - 2);
       const title = `${new Date(b.ts).toLocaleTimeString()} : ${b.events} events/min`;
-      return `<rect class="throughput-bar" data-label="${escapeHtml(title)}" x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${w.toFixed(2)}" height="${barH.toFixed(2)}" fill="rgb(226 109 92 / 70%)"></rect>`;
+      return `<rect class="throughput-bar" data-label="${escapeHtml(title)}" x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${w.toFixed(2)}" height="${barH.toFixed(2)}" fill="${barColor}"></rect>`;
     })
     .join('');
 
   throughputChart.innerHTML = `
     <title>분당 이벤트 처리량 바 차트</title>
-    <line x1="${left}" y1="${bottom}" x2="${right}" y2="${bottom}" stroke="rgb(226 109 92 / 45%)" stroke-width="1" />
-    <line x1="${left}" y1="${top}" x2="${left}" y2="${bottom}" stroke="rgb(226 109 92 / 30%)" stroke-width="1" />
-    <line x1="${left}" y1="${midY}" x2="${right}" y2="${midY}" stroke="rgb(226 109 92 / 15%)" stroke-width="1" stroke-dasharray="4 4" />
+    <line x1="${left}" y1="${bottom}" x2="${right}" y2="${bottom}" stroke="${axisColor}" stroke-width="1" />
+    <line x1="${left}" y1="${top}" x2="${left}" y2="${bottom}" stroke="${axisSecondary}" stroke-width="1" />
+    <line x1="${left}" y1="${midY}" x2="${right}" y2="${midY}" stroke="${axisMid}" stroke-width="1" stroke-dasharray="4 4" />
     ${bars}
-    <text x="${left}" y="${top - 4}" font-size="10" fill="rgb(226 109 92 / 80%)">max ${max}</text>
-    <text x="${left}" y="${midY - 4}" font-size="9" fill="rgb(226 109 92 / 55%)">${Math.round(max / 2)}</text>
+    <text x="${left}" y="${top - 4}" font-size="10" fill="${labelColor}">max ${max}</text>
+    <text x="${left}" y="${midY - 4}" font-size="9" fill="${sublabelColor}">${Math.round(max / 2)}</text>
     ${[25, 20, 15, 10, 5, 0]
       .map((minAgo) => {
         const idx = buckets.length - minAgo - 1;
         if (idx < 0 || idx >= buckets.length) return '';
         const x = left + idx * slot + slot / 2;
         const label = minAgo === 0 ? 'now' : `-${minAgo}m`;
-        return `<text x="${x.toFixed(2)}" y="${bottom + 14}" font-size="9" text-anchor="middle" fill="rgb(226 109 92 / 60%)">${label}</text>`;
+        return `<text x="${x.toFixed(2)}" y="${bottom + 14}" font-size="9" text-anchor="middle" fill="${timescaleColor}">${label}</text>`;
       })
       .join('')}
   `;
@@ -306,14 +318,22 @@ function renderTokenTrendChart(events = []) {
     )
   ).sort();
 
+  const axisColor = cssVar('--chart-axis');
+
   if (!agents.length) {
     tokenTrendChart.innerHTML = `
       <title>모델별 분당 토큰 사용량 추이 차트</title>
-      <line x1="36" y1="190" x2="620" y2="190" stroke="rgb(226 109 92 / 45%)" stroke-width="1" />
+      <line x1="36" y1="190" x2="620" y2="190" stroke="${axisColor}" stroke-width="1" />
     `;
     tokenTrendLegend.innerHTML = '<span>No token data</span>';
     return;
   }
+
+  const axisSecondary = cssVar('--chart-axis-secondary');
+  const axisMid = cssVar('--chart-axis-mid');
+  const labelColor = cssVar('--chart-label');
+  const sublabelColor = cssVar('--chart-sublabel');
+  const timescaleColor = cssVar('--chart-timescale');
 
   const width = { left: 36, right: 620 };
   const height = { top: 20, bottom: 190 };
@@ -348,20 +368,20 @@ function renderTokenTrendChart(events = []) {
 
   tokenTrendChart.innerHTML = `
     <title>모델별 분당 토큰 사용량 추이 차트</title>
-    <line x1="${width.left}" y1="${height.bottom}" x2="${width.right}" y2="${height.bottom}" stroke="rgb(226 109 92 / 45%)" stroke-width="1" />
-    <line x1="${width.left}" y1="${height.top}" x2="${width.left}" y2="${height.bottom}" stroke="rgb(226 109 92 / 30%)" stroke-width="1" />
-    <line x1="${width.left}" y1="${midY}" x2="${width.right}" y2="${midY}" stroke="rgb(226 109 92 / 15%)" stroke-width="1" stroke-dasharray="4 4" />
+    <line x1="${width.left}" y1="${height.bottom}" x2="${width.right}" y2="${height.bottom}" stroke="${axisColor}" stroke-width="1" />
+    <line x1="${width.left}" y1="${height.top}" x2="${width.left}" y2="${height.bottom}" stroke="${axisSecondary}" stroke-width="1" />
+    <line x1="${width.left}" y1="${midY}" x2="${width.right}" y2="${midY}" stroke="${axisMid}" stroke-width="1" stroke-dasharray="4 4" />
     ${lineSvg}
     ${endLabels}
-    <text x="${width.left}" y="${height.top - 4}" font-size="10" fill="rgb(226 109 92 / 80%)">max ${max}</text>
-    <text x="${width.left}" y="${midY - 4}" font-size="9" fill="rgb(226 109 92 / 55%)">${Math.round(max / 2)}</text>
+    <text x="${width.left}" y="${height.top - 4}" font-size="10" fill="${labelColor}">max ${max}</text>
+    <text x="${width.left}" y="${midY - 4}" font-size="9" fill="${sublabelColor}">${Math.round(max / 2)}</text>
     ${[25, 20, 15, 10, 5, 0]
       .map((minAgo) => {
         const idx = buckets.length - minAgo - 1;
         if (idx < 0 || idx >= buckets.length) return '';
         const x = width.left + idx * slotWidth;
         const label = minAgo === 0 ? 'now' : `-${minAgo}m`;
-        return `<text x="${x.toFixed(2)}" y="${height.bottom + 14}" font-size="9" text-anchor="middle" fill="rgb(226 109 92 / 60%)">${label}</text>`;
+        return `<text x="${x.toFixed(2)}" y="${height.bottom + 14}" font-size="9" text-anchor="middle" fill="${timescaleColor}">${label}</text>`;
       })
       .join('')}
   `;
@@ -598,6 +618,12 @@ eventSearch.addEventListener('input', () => {
     const filtered = getFilteredEvents(allEvents);
     renderEvents(filtered);
     renderEventMeta(allEvents.length, filtered.length);
+  }
+});
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  if (snapshotState) {
+    renderGraphs(snapshotState.recent || []);
   }
 });
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Claude Pulse</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>

--- a/public/lib/palette.js
+++ b/public/lib/palette.js
@@ -4,5 +4,11 @@ export const CHART_PALETTE = [
 ];
 
 export function colorForIndex(idx) {
-  return CHART_PALETTE[idx % CHART_PALETTE.length];
+  const fallback = CHART_PALETTE[idx % CHART_PALETTE.length];
+  if (typeof document === 'undefined') return fallback;
+  const i = (idx % CHART_PALETTE.length) + 1;
+  const cssVar = getComputedStyle(document.documentElement)
+    .getPropertyValue(`--chart-${i}`)
+    .trim();
+  return cssVar || fallback;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -23,6 +23,21 @@
 
   --hover-overlay: rgb(226 109 92 / 8%);
   --focus-ring: rgb(226 109 92 / 60%);
+
+  --surface-card: rgb(246 237 227 / 70%);
+  --surface-chart: rgb(246 237 227 / 82%);
+  --surface-tooltip: rgb(246 237 227 / 95%);
+  --surface-event: rgb(246 237 227 / 78%);
+
+  --chart-axis: rgb(226 109 92 / 45%);
+  --chart-axis-secondary: rgb(226 109 92 / 30%);
+  --chart-axis-mid: rgb(226 109 92 / 15%);
+  --chart-bar: rgb(226 109 92 / 70%);
+  --chart-label: rgb(226 109 92 / 80%);
+  --chart-sublabel: rgb(226 109 92 / 55%);
+  --chart-timescale: rgb(226 109 92 / 60%);
+  --shadow-hover: rgb(226 109 92 / 16%);
+  --shadow-hover-subtle: rgb(226 109 92 / 12%);
 }
 
 * {
@@ -99,7 +114,7 @@ main {
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgb(226 109 92 / 16%);
+  box-shadow: 0 4px 16px var(--shadow-hover);
 }
 
 .card--ok {
@@ -208,13 +223,13 @@ input[type='search']:focus {
   padding: 10px;
   display: grid;
   gap: 4px;
-  background: rgb(246 237 227 / 70%);
+  background: var(--surface-card);
   transition: transform 0.12s ease, box-shadow 0.12s ease;
 }
 
 .workflow-item:hover {
   transform: translateY(-1px);
-  box-shadow: 0 3px 12px rgb(226 109 92 / 12%);
+  box-shadow: 0 3px 12px var(--shadow-hover-subtle);
 }
 
 .charts-grid {
@@ -228,7 +243,7 @@ input[type='search']:focus {
   border: 1px solid var(--border-medium);
   border-radius: 10px;
   padding: 10px;
-  background: rgb(246 237 227 / 70%);
+  background: var(--surface-card);
 }
 
 .chart-card h3 {
@@ -241,7 +256,7 @@ input[type='search']:focus {
   height: 200px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgb(246 237 227 / 82%);
+  background: var(--surface-chart);
 }
 
 .token-trend-chart {
@@ -249,7 +264,7 @@ input[type='search']:focus {
   height: 200px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgb(246 237 227 / 82%);
+  background: var(--surface-chart);
 }
 
 .token-legend {
@@ -283,7 +298,7 @@ input[type='search']:focus {
   font-size: 11px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: rgb(246 237 227 / 95%);
+  background: var(--surface-tooltip);
   pointer-events: none;
 }
 
@@ -324,7 +339,7 @@ tbody tr:hover td {
   padding: 9px;
   border-radius: 10px;
   border: 1px solid var(--border-medium);
-  background: rgb(246 237 227 / 78%);
+  background: var(--surface-event);
   font-size: 13px;
   align-items: center;
   transition: background 0.12s ease, border-color 0.12s ease;
@@ -401,6 +416,56 @@ tbody tr:hover td {
   border-width: 2px;
   border-color: var(--color-error);
   color: var(--color-error);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #1A1A2E;
+    --warm: #E8806F;
+    --warm-text: #F0A898;
+
+    --color-ok: #4ADE80;
+    --color-warning: #FBBF24;
+    --color-error: #F87171;
+
+    --chart-1: #60A5FA;
+    --chart-2: #FB923C;
+    --chart-3: #F87171;
+    --chart-4: #34D399;
+    --chart-5: #A3E635;
+    --chart-6: #FBBF24;
+    --chart-7: #C084FC;
+    --chart-8: #FB7185;
+
+    --surface: rgb(30 30 50 / 86%);
+    --surface-card: rgb(30 30 50 / 70%);
+    --surface-chart: rgb(30 30 50 / 82%);
+    --surface-tooltip: rgb(20 20 40 / 95%);
+    --surface-event: rgb(30 30 50 / 78%);
+
+    --border: rgb(232 128 111 / 40%);
+    --border-subtle: rgb(232 128 111 / 24%);
+    --border-medium: rgb(232 128 111 / 30%);
+    --hover-overlay: rgb(232 128 111 / 8%);
+    --focus-ring: rgb(232 128 111 / 60%);
+
+    --chart-axis: rgb(232 128 111 / 45%);
+    --chart-axis-secondary: rgb(232 128 111 / 30%);
+    --chart-axis-mid: rgb(232 128 111 / 15%);
+    --chart-bar: rgb(232 128 111 / 70%);
+    --chart-label: rgb(232 128 111 / 80%);
+    --chart-sublabel: rgb(232 128 111 / 55%);
+    --chart-timescale: rgb(232 128 111 / 60%);
+    --shadow-hover: rgb(232 128 111 / 16%);
+    --shadow-hover-subtle: rgb(232 128 111 / 12%);
+  }
+
+  body {
+    background:
+      radial-gradient(circle at 10% 10%, rgb(232 128 111 / 8%), transparent 40%),
+      radial-gradient(circle at 90% 80%, rgb(232 128 111 / 5%), transparent 45%),
+      var(--paper);
+  }
 }
 
 @media (max-width: 1080px) {


### PR DESCRIPTION
## Summary
- `@media (prefers-color-scheme: dark)` 미디어 쿼리로 시스템 설정에 따른 자동 다크 모드 지원
- CSS 변수 기반 설계를 활용해 하드코딩 색상을 변수화하고 다크 팔레트로 오버라이드
- SVG 차트 색상을 `getComputedStyle`로 CSS 변수에서 런타임에 읽어 다크 모드 팔레트 자동 적용

## Changes
- `public/index.html`: `<meta name="color-scheme" content="light dark">` 추가
- `public/styles.css`: 하드코딩 `rgb()` 11개 CSS 변수화, `@media (prefers-color-scheme: dark)` 블록 추가 (배경·브랜드·시맨틱·차트·표면·테두리 변수 오버라이드)
- `public/app.js`: `cssVar()` 헬퍼로 SVG 차트 색상 CSS 변수 런타임 참조, `matchMedia` change 리스너로 다크 모드 전환 시 차트 재렌더링
- `public/lib/palette.js`: `colorForIndex()`가 CSS 변수 `--chart-1~8`을 런타임에 읽고, `document` 없는 환경에서는 fallback 팔레트 사용

## Related Issue
Closes #51

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] 브라우저 DevTools > Rendering > "Emulate CSS prefers-color-scheme: dark"로 다크 모드 전환 확인
- [ ] 다크 모드: 배경 `#1A1A2E`, 텍스트 `#F0A898`으로 전환되는지 확인
- [ ] SVG 차트 색상 다크 팔레트 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)