### PR TITLE
feat(ui): 모든 에이전트를 계층형 트리로 동적 표시

### DIFF
--- a/__tests__/server-logic.test.js
+++ b/__tests__/server-logic.test.js
@@ -75,6 +75,21 @@ describe('buildSnapshot', () => {
     assert.equal(snap.workflowProgress[1].roleId, 'frontend');
   });
 
+  it('aggregates tokenTotal and costTotalUsd in totals', () => {
+    const state = {
+      recent: [],
+      alerts: [],
+      byAgent: new Map([
+        ['a1', { agentId: 'a1', lastSeen: '', total: 5, ok: 5, warning: 0, error: 0, lastEvent: '', latencyMs: null, tokenTotal: 1000, costUsd: 0.5 }],
+        ['a2', { agentId: 'a2', lastSeen: '', total: 3, ok: 3, warning: 0, error: 0, lastEvent: '', latencyMs: null, tokenTotal: 500, costUsd: 0.2 }]
+      ]),
+      bySource: new Map()
+    };
+    const snap = buildSnapshot(state);
+    assert.equal(snap.totals.tokenTotal, 1500);
+    assert.ok(Math.abs(snap.totals.costTotalUsd - 0.7) < 1e-9);
+  });
+
   it('sorts workflowProgress alphabetically by agent key', () => {
     const state = {
       recent: [],

--- a/public/__tests__/agent-tree.test.js
+++ b/public/__tests__/agent-tree.test.js
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAgentTree } from '../lib/agent-tree.js';
+
+describe('buildAgentTree', () => {
+  it('returns empty array for empty agents', () => {
+    assert.deepStrictEqual(buildAgentTree([]), []);
+  });
+
+  it('groups lead and sub-agents by sessionId', () => {
+    const agents = [
+      { agentId: 'lead-abcdef12', sessionId: 'abcdef1234567890', isSidechain: false, model: 'claude-opus-4-6' },
+      { agentId: 'agent-abc', sessionId: 'abcdef1234567890', isSidechain: true, model: 'claude-haiku-4-5' },
+      { agentId: 'agent-def', sessionId: 'abcdef1234567890', isSidechain: true, model: 'claude-sonnet-4-6' }
+    ];
+    const tree = buildAgentTree(agents);
+    assert.equal(tree.length, 1);
+    assert.equal(tree[0].agent.agentId, 'lead-abcdef12');
+    assert.equal(tree[0].children.length, 2);
+    assert.ok(tree[0].children.some((c) => c.agentId === 'agent-abc'));
+    assert.ok(tree[0].children.some((c) => c.agentId === 'agent-def'));
+  });
+
+  it('handles standalone agents without sessionId', () => {
+    const agents = [
+      { agentId: 'solo', sessionId: '', isSidechain: false }
+    ];
+    const tree = buildAgentTree(agents);
+    assert.equal(tree.length, 1);
+    assert.equal(tree[0].agent.agentId, 'solo');
+    assert.equal(tree[0].children.length, 0);
+  });
+
+  it('handles multiple sessions', () => {
+    const agents = [
+      { agentId: 'lead-sess1aaa', sessionId: 'sess1aaa12345678', isSidechain: false },
+      { agentId: 'agent-a', sessionId: 'sess1aaa12345678', isSidechain: true },
+      { agentId: 'lead-sess2bbb', sessionId: 'sess2bbb12345678', isSidechain: false },
+      { agentId: 'agent-b', sessionId: 'sess2bbb12345678', isSidechain: true }
+    ];
+    const tree = buildAgentTree(agents);
+    assert.equal(tree.length, 2);
+  });
+
+  it('does not overwrite multiple leads with empty sessionId', () => {
+    const agents = [
+      { agentId: 'lead-aaa', sessionId: '', isSidechain: false },
+      { agentId: 'lead-bbb', sessionId: '', isSidechain: false },
+      { agentId: 'lead-ccc', sessionId: '', isSidechain: false }
+    ];
+    const tree = buildAgentTree(agents);
+    assert.equal(tree.length, 3);
+    const ids = tree.map((n) => n.agent.agentId).sort();
+    assert.deepStrictEqual(ids, ['lead-aaa', 'lead-bbb', 'lead-ccc']);
+  });
+
+  it('treats sidechain without lead as standalone root', () => {
+    const agents = [
+      { agentId: 'agent-orphan', sessionId: 'orphan1234567890', isSidechain: true }
+    ];
+    const tree = buildAgentTree(agents);
+    assert.equal(tree.length, 1);
+    assert.equal(tree[0].agent.agentId, 'agent-orphan');
+    assert.equal(tree[0].children.length, 0);
+  });
+});

--- a/public/__tests__/workflow.test.js
+++ b/public/__tests__/workflow.test.js
@@ -51,7 +51,7 @@ describe('recalcWorkflow', () => {
 
   it('preserves all agent fields in output', () => {
     const agents = [
-      { agentId: 'alpha', error: 0, warning: 0, total: 3, lastEvent: 'ping', lastSeen: '2026-02-28T12:00:00Z' }
+      { agentId: 'alpha', error: 0, warning: 0, total: 3, lastEvent: 'ping', lastSeen: '2026-02-28T12:00:00Z', model: 'claude-opus-4-6' }
     ];
     const result = recalcWorkflow(agents);
     assert.deepStrictEqual(result[0], {
@@ -60,7 +60,8 @@ describe('recalcWorkflow', () => {
       status: 'running',
       total: 3,
       lastEvent: 'ping',
-      lastSeen: '2026-02-28T12:00:00Z'
+      lastSeen: '2026-02-28T12:00:00Z',
+      model: 'claude-opus-4-6'
     });
   });
 

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,7 @@
 import { recalcWorkflow } from './lib/workflow.js';
 import { buildCardData } from './lib/cards.js';
 import { colorForIndex } from './lib/palette.js';
+import { buildAgentTree } from './lib/agent-tree.js';
 
 const cardsRoot = document.getElementById('cards');
 const throughputChart = document.getElementById('throughputChart');
@@ -118,29 +119,44 @@ function renderSources(rows = []) {
     .join('');
 }
 
+function agentRowHtml(row, isChild, isLastChild) {
+  const prefix = isChild ? '<span class="tree-branch"></span>' : '';
+  const classes = [isChild && 'tree-child', isLastChild && 'tree-last'].filter(Boolean).join(' ');
+  const cls = classes ? ` class="${classes}"` : '';
+  const modelBadge = row.model
+    ? `<span class="model-badge">${escapeHtml(row.model)}</span>`
+    : '-';
+  return `
+    <tr${cls}>
+      <td>${prefix}<span class="badge">${escapeHtml(row.agentId)}</span></td>
+      <td>${modelBadge}</td>
+      <td>${new Date(row.lastSeen).toLocaleTimeString()}</td>
+      <td>${Number(row.total) || 0}</td>
+      <td>${Number(row.ok) || 0}</td>
+      <td>${Number(row.warning) || 0}</td>
+      <td>${Number(row.error) || 0}</td>
+      <td>${numberFmt.format(row.tokenTotal || 0)}</td>
+      <td>${escapeHtml(row.lastEvent)}</td>
+      <td>${row.latencyMs == null ? '-' : `${row.latencyMs} ms`}</td>
+    </tr>`;
+}
+
 function renderAgents(agents) {
   const filtered =
     agentFilter.value === 'all'
       ? agents
       : agents.filter((row) => row.agentId === agentFilter.value);
 
-  agentsBody.innerHTML = filtered
-    .map(
-      (row) => `
-      <tr>
-        <td><span class="badge">${escapeHtml(row.agentId)}</span></td>
-        <td>${new Date(row.lastSeen).toLocaleTimeString()}</td>
-        <td>${Number(row.total) || 0}</td>
-        <td>${Number(row.ok) || 0}</td>
-        <td>${Number(row.warning) || 0}</td>
-        <td>${Number(row.error) || 0}</td>
-        <td>${numberFmt.format(row.tokenTotal || 0)}</td>
-        <td>${escapeHtml(row.lastEvent)}</td>
-        <td>${row.latencyMs == null ? '-' : `${row.latencyMs} ms`}</td>
-      </tr>
-    `
-    )
-    .join('');
+  const tree = buildAgentTree(filtered);
+  const rows = [];
+  for (const node of tree) {
+    rows.push(agentRowHtml(node.agent, false, false));
+    for (let i = 0; i < node.children.length; i++) {
+      const isLast = i === node.children.length - 1;
+      rows.push(agentRowHtml(node.children[i], true, isLast));
+    }
+  }
+  agentsBody.innerHTML = rows.join('');
 }
 
 function normalizeText(v) {
@@ -413,10 +429,10 @@ function populateAgentFilter(agents = []) {
   const prev = agentFilter.value;
   const ids = agents.map((row) => row.agentId);
   agentFilter.querySelectorAll('option:not([value="all"])').forEach((o) => o.remove());
-  for (const id of ids) {
+  for (const agent of agents) {
     const opt = document.createElement('option');
-    opt.value = id;
-    opt.textContent = id;
+    opt.value = agent.agentId;
+    opt.textContent = agent.isSidechain ? `\u21b3 ${agent.agentId}` : agent.agentId;
     agentFilter.appendChild(opt);
   }
   if (ids.includes(prev) || prev === 'all') {
@@ -426,6 +442,14 @@ function populateAgentFilter(agents = []) {
   }
 }
 
+
+function extractAgentMeta(evt) {
+  return {
+    model: evt.model || evt.metadata?.model || '',
+    isSidechain: evt.isSidechain ?? evt.metadata?.isSidechain ?? false,
+    sessionId: evt.sessionId || evt.metadata?.sessionId || ''
+  };
+}
 
 function applyIncrementalEvent(evt) {
   if (!snapshotState) return;
@@ -438,6 +462,7 @@ function applyIncrementalEvent(evt) {
   else if (evt.status === 'warning') totals.warning += 1;
   else totals.ok += 1;
 
+  const meta = extractAgentMeta(evt);
   const agents = snapshotState.agents;
   const agent = agents.find((row) => row.agentId === evt.agentId);
   if (!agent) {
@@ -450,7 +475,10 @@ function applyIncrementalEvent(evt) {
       error: evt.status === 'error' ? 1 : 0,
       tokenTotal: evtTokenTotal,
       lastEvent: evt.event,
-      latencyMs: evt.latencyMs ?? null
+      latencyMs: evt.latencyMs ?? null,
+      model: meta.model,
+      isSidechain: meta.isSidechain,
+      sessionId: meta.sessionId
     });
     totals.agents = agents.length;
     populateAgentFilter(agents);
@@ -460,6 +488,9 @@ function applyIncrementalEvent(evt) {
     agent.lastEvent = evt.event;
     agent.latencyMs = evt.latencyMs ?? null;
     agent.tokenTotal = (agent.tokenTotal || 0) + evtTokenTotal;
+    if (meta.model) agent.model = meta.model;
+    if (meta.isSidechain) agent.isSidechain = meta.isSidechain;
+    if (meta.sessionId) agent.sessionId = meta.sessionId;
     if (evt.status === 'error') agent.error += 1;
     else if (evt.status === 'warning') agent.warning += 1;
     else agent.ok += 1;

--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,7 @@
           <thead>
             <tr>
               <th>Agent</th>
+              <th>Model</th>
               <th>Last Seen</th>
               <th>Total</th>
               <th>OK</th>

--- a/public/lib/agent-tree.js
+++ b/public/lib/agent-tree.js
@@ -1,0 +1,38 @@
+/**
+ * Build a hierarchical tree from a flat agents array.
+ * Groups agents by sessionId — lead (isSidechain === false) becomes root,
+ * sub-agents (isSidechain === true) become children.
+ *
+ * @param {Array} agents - flat array of agent rows
+ * @returns {Array<{agent: object, children: object[]}>}
+ */
+export function buildAgentTree(agents) {
+  const bySession = new Map();
+
+  for (const agent of agents) {
+    const sid = agent.sessionId || '';
+    const key = sid || agent.agentId || '';
+    if (!bySession.has(key)) {
+      bySession.set(key, { lead: null, children: [] });
+    }
+    const group = bySession.get(key);
+    if (!agent.isSidechain) {
+      group.lead = agent;
+    } else {
+      group.children.push(agent);
+    }
+  }
+
+  const tree = [];
+  for (const [, group] of bySession) {
+    if (group.lead) {
+      tree.push({ agent: group.lead, children: group.children });
+    } else {
+      for (const child of group.children) {
+        tree.push({ agent: child, children: [] });
+      }
+    }
+  }
+
+  return tree;
+}

--- a/public/lib/workflow.js
+++ b/public/lib/workflow.js
@@ -7,7 +7,8 @@ export function recalcWorkflow(agents = []) {
       status,
       total: row.total,
       lastEvent: row.lastEvent,
-      lastSeen: row.lastSeen
+      lastSeen: row.lastSeen,
+      model: row.model || ''
     };
   });
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -514,3 +514,28 @@ tbody tr:hover td {
     min-width: unset;
   }
 }
+
+/* ── Agent tree styles ── */
+tr.tree-child td:first-child {
+  padding-left: 28px;
+}
+
+.tree-branch::before {
+  content: "\251C\2500";
+  color: var(--border);
+  margin-right: 4px;
+  font-size: 12px;
+}
+
+tr.tree-last .tree-branch::before {
+  content: "\2514\2500";
+}
+
+.model-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  background: var(--border-subtle);
+  color: var(--warm-text);
+}

--- a/scripts/__tests__/claude-local-collector.test.js
+++ b/scripts/__tests__/claude-local-collector.test.js
@@ -103,6 +103,30 @@ describe('sessionLineToEvent', () => {
       assert.equal(events[0].metadata.sessionId, 's1');
     });
 
+    it('uses agentId when present', () => {
+      const line = JSON.stringify({
+        type: 'user',
+        agentId: 'agent-abc',
+        isSidechain: true,
+        sessionId: 'abcdef1234567890',
+        message: { content: 'hi' }
+      });
+      const events = sessionLineToEvent(line);
+      assert.equal(events[0].agentId, 'agent-abc');
+      assert.equal(events[0].metadata.isSidechain, true);
+    });
+
+    it('falls back to lead-<sessionId8> when agentId missing', () => {
+      const line = JSON.stringify({
+        type: 'user',
+        sessionId: 'abcdef1234567890',
+        message: { content: 'hi' }
+      });
+      const events = sessionLineToEvent(line);
+      assert.equal(events[0].agentId, 'lead-abcdef12');
+      assert.equal(events[0].metadata.isSidechain, false);
+    });
+
     it('parses array content', () => {
       const line = JSON.stringify({
         type: 'user',
@@ -149,6 +173,22 @@ describe('sessionLineToEvent', () => {
       assert.equal(events[0].event, 'assistant_message');
       assert.equal(events[0].message, 'response');
       assert.equal(events[0].metadata.model, 'claude-3');
+    });
+
+    it('uses agentId for assistant messages', () => {
+      const line = JSON.stringify({
+        type: 'assistant',
+        agentId: 'agent-xyz',
+        isSidechain: true,
+        sessionId: 'sess12345678',
+        message: {
+          model: 'claude-haiku-4-5',
+          content: [{ type: 'text', text: 'ok' }]
+        }
+      });
+      const events = sessionLineToEvent(line);
+      assert.equal(events[0].agentId, 'agent-xyz');
+      assert.equal(events[0].metadata.isSidechain, true);
     });
 
     it('parses tool_use content', () => {
@@ -341,6 +381,22 @@ describe('walkJsonlFiles', () => {
 
     const result = await walkJsonlFiles(tmpDir);
     assert.equal(result.length, 2);
+  });
+
+  it('finds sub-agent files in subagents/ directory', async () => {
+    const session = join(tmpDir, 'session1');
+    const subagents = join(session, 'subagents');
+    await mkdir(subagents, { recursive: true });
+    await writeFile(join(session, 'lead.jsonl'), '');
+    await writeFile(join(subagents, 'agent-abc.jsonl'), '');
+    await writeFile(join(subagents, 'agent-def.jsonl'), '');
+    await writeFile(join(subagents, 'notes.txt'), ''); // should be ignored
+
+    const result = await walkJsonlFiles(tmpDir);
+    assert.equal(result.length, 3); // lead + 2 sub-agents
+    assert.ok(result.every((f) => f.endsWith('.jsonl')));
+    const subFiles = result.filter((f) => f.includes('subagents'));
+    assert.equal(subFiles.length, 2);
   });
 });
 

--- a/scripts/claude-local-collector.js
+++ b/scripts/claude-local-collector.js
@@ -132,6 +132,8 @@ function sessionLineToEvent(line) {
 
   const msgType = parsed.type || '';
   const sessionId = parsed.sessionId || '';
+  const isSidechain = parsed.isSidechain ?? false;
+  const agentId = parsed.agentId || `lead-${sessionId.slice(0, 8)}`;
   const timestamp = parsed.timestamp || new Date().toISOString();
 
   if (msgType === 'user') {
@@ -145,14 +147,15 @@ function sessionLineToEvent(line) {
 
     return [
       {
-        agentId: 'lead',
+        agentId,
         event: 'user_message',
         status: 'ok',
         message: content.slice(0, 120),
         timestamp,
         metadata: {
           source: 'claude_session',
-          sessionId
+          sessionId,
+          isSidechain
         }
       }
     ];
@@ -169,7 +172,7 @@ function sessionLineToEvent(line) {
 
       if (itemType === 'text' && item.text) {
         events.push({
-          agentId: 'lead',
+          agentId,
           event: 'assistant_message',
           status: 'ok',
           message: String(item.text).slice(0, 120),
@@ -177,7 +180,8 @@ function sessionLineToEvent(line) {
           metadata: {
             source: 'claude_session',
             sessionId,
-            model
+            model,
+            isSidechain
           }
         });
       }
@@ -185,7 +189,7 @@ function sessionLineToEvent(line) {
       if (itemType === 'tool_use') {
         const inputStr = JSON.stringify(item.input || {});
         events.push({
-          agentId: 'lead',
+          agentId,
           event: 'tool_call',
           status: 'ok',
           message: item.name || 'unknown_tool',
@@ -194,6 +198,7 @@ function sessionLineToEvent(line) {
             source: 'claude_session',
             sessionId,
             model,
+            isSidechain,
             toolInput: inputStr.length > 512 ? { _truncated: true } : (item.input || {})
           }
         });
@@ -213,7 +218,7 @@ function sessionLineToEvent(line) {
 
       if (total > 0) {
         events.push({
-          agentId: 'lead',
+          agentId,
           event: 'token_usage',
           status: 'ok',
           message: `tokens +${total}`,
@@ -222,6 +227,7 @@ function sessionLineToEvent(line) {
             source: 'claude_session',
             sessionId,
             model,
+            isSidechain,
             tokenUsage: {
               inputTokens,
               outputTokens,
@@ -260,6 +266,19 @@ async function walkJsonlFiles(dir) {
     for (const subEntry of subEntries) {
       if (subEntry.isFile() && subEntry.name.endsWith('.jsonl')) {
         result.push(join(subDir, subEntry.name));
+      } else if (subEntry.isDirectory() && subEntry.name === 'subagents') {
+        const agentDir = join(subDir, subEntry.name);
+        let agentEntries;
+        try {
+          agentEntries = await readdir(agentDir, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+        for (const agentEntry of agentEntries) {
+          if (agentEntry.isFile() && agentEntry.name.endsWith('.jsonl')) {
+            result.push(join(agentDir, agentEntry.name));
+          }
+        }
       }
     }
   }

--- a/server-logic.js
+++ b/server-logic.js
@@ -38,9 +38,11 @@ export function buildSnapshot(state) {
       acc.ok += row.ok;
       acc.warning += row.warning;
       acc.error += row.error;
+      acc.tokenTotal += row.tokenTotal || 0;
+      acc.costTotalUsd += row.costUsd || 0;
       return acc;
     },
-    { agents: agentRows.length, total: 0, ok: 0, warning: 0, error: 0 }
+    { agents: agentRows.length, total: 0, ok: 0, warning: 0, error: 0, tokenTotal: 0, costTotalUsd: 0 }
   );
   const sources = [...state.bySource.values()].sort((a, b) => a.source.localeCompare(b.source));
 

--- a/server.js
+++ b/server.js
@@ -86,13 +86,25 @@ function appendEvent(evt) {
     warning: 0,
     error: 0,
     lastEvent: evt.event,
-    latencyMs: null
+    latencyMs: null,
+    model: '',
+    isSidechain: false,
+    sessionId: '',
+    tokenTotal: 0,
+    costUsd: 0
   };
 
   prev.lastSeen = evt.receivedAt;
   prev.total += 1;
   prev.lastEvent = evt.event;
   prev.latencyMs = evt.latencyMs;
+  if (evt.metadata?.model) prev.model = evt.metadata.model;
+  if (evt.metadata?.isSidechain != null) prev.isSidechain = evt.metadata.isSidechain;
+  if (evt.metadata?.sessionId) prev.sessionId = evt.metadata.sessionId;
+  prev.tokenTotal = (prev.tokenTotal || 0) + (evt.metadata?.tokenUsage?.totalTokens || 0);
+  if (evt.event === 'cost_update') {
+    prev.costUsd = (prev.costUsd || 0) + (evt.metadata?.costDelta || 0);
+  }
 
   if (evt.status === 'error') prev.error += 1;
   else if (evt.status === 'warning') prev.warning += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ struct Event {
     metadata: Value,
     timestamp: String,
     received_at: String,
+    model: String,
+    is_sidechain: bool,
+    session_id: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -49,6 +52,9 @@ struct AgentRow {
     cost_usd: f64,
     last_event: String,
     latency_ms: Option<i64>,
+    model: String,
+    is_sidechain: bool,
+    session_id: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -234,12 +240,22 @@ fn append_event(app: &App, evt: Event) {
                 cost_usd: 0.0,
                 last_event: evt.event.clone(),
                 latency_ms: None,
+                model: evt.model.clone(),
+                is_sidechain: evt.is_sidechain,
+                session_id: evt.session_id.clone(),
             });
 
         row.last_seen = evt.received_at.clone();
         row.total += 1;
         row.last_event = evt.event.clone();
         row.latency_ms = evt.latency_ms;
+        if !evt.model.is_empty() {
+            row.model = evt.model.clone();
+        }
+        row.is_sidechain = evt.is_sidechain;
+        if !evt.session_id.is_empty() {
+            row.session_id = evt.session_id.clone();
+        }
         match evt.status.as_str() {
             "error" => row.error += 1,
             "warning" => row.warning += 1,
@@ -421,6 +437,11 @@ fn normalize_incoming(payload: &Value, app: &App) -> Event {
         .map(status_norm)
         .unwrap_or_else(|| "ok".to_string());
 
+    let meta = payload
+        .get("metadata")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
     Event {
         id: format!("e{}", app.event_seq.fetch_add(1, Ordering::Relaxed)),
         agent_id: payload
@@ -440,10 +461,21 @@ fn normalize_incoming(payload: &Value, app: &App) -> Event {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
-        metadata: payload
-            .get("metadata")
-            .cloned()
-            .unwrap_or_else(|| json!({})),
+        model: meta
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        is_sidechain: meta
+            .get("isSidechain")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        session_id: meta
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        metadata: meta,
         timestamp: ts,
         received_at: now,
     }
@@ -689,6 +721,9 @@ fn parse_history_event(line: &str, app: &App) -> Option<Event> {
         }),
         timestamp: dt,
         received_at: now_iso(),
+        model: String::new(),
+        is_sidechain: false,
+        session_id: String::new(),
     })
 }
 
@@ -704,6 +739,18 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
         .and_then(|s| s.as_str())
         .unwrap_or("")
         .to_string();
+    let is_sidechain = v
+        .get("isSidechain")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    let agent_id = v
+        .get("agentId")
+        .and_then(|a| a.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            let prefix: String = session_id.chars().take(8).collect();
+            format!("lead-{}", prefix)
+        });
     let timestamp = v
         .get("timestamp")
         .and_then(|t| t.as_str())
@@ -724,7 +771,7 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
 
             vec![Event {
                 id: format!("e{}", app.event_seq.fetch_add(1, Ordering::Relaxed)),
-                agent_id: "lead".to_string(),
+                agent_id: agent_id.clone(),
                 event: "user_message".to_string(),
                 status: "ok".to_string(),
                 latency_ms: None,
@@ -732,9 +779,13 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                 metadata: json!({
                     "source": "claude_session",
                     "sessionId": session_id,
+                    "isSidechain": is_sidechain,
                 }),
                 timestamp,
                 received_at: now_iso(),
+                model: String::new(),
+                is_sidechain,
+                session_id: session_id.clone(),
             }]
         }
         "assistant" => {
@@ -758,7 +809,7 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                                         "e{}",
                                         app.event_seq.fetch_add(1, Ordering::Relaxed)
                                     ),
-                                    agent_id: "lead".to_string(),
+                                    agent_id: agent_id.clone(),
                                     event: "assistant_message".to_string(),
                                     status: "ok".to_string(),
                                     latency_ms: None,
@@ -767,9 +818,13 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                                         "source": "claude_session",
                                         "sessionId": session_id,
                                         "model": model,
+                                        "isSidechain": is_sidechain,
                                     }),
                                     timestamp: timestamp.clone(),
                                     received_at: now_iso(),
+                                    model: model.clone(),
+                                    is_sidechain,
+                                    session_id: session_id.clone(),
                                 });
                             }
                         }
@@ -781,7 +836,7 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                             let input = item.get("input").cloned().unwrap_or(json!({}));
                             events.push(Event {
                                 id: format!("e{}", app.event_seq.fetch_add(1, Ordering::Relaxed)),
-                                agent_id: "lead".to_string(),
+                                agent_id: agent_id.clone(),
                                 event: "tool_call".to_string(),
                                 status: "ok".to_string(),
                                 latency_ms: None,
@@ -790,10 +845,14 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                                     "source": "claude_session",
                                     "sessionId": session_id,
                                     "model": model,
+                                    "isSidechain": is_sidechain,
                                     "toolInput": input,
                                 }),
                                 timestamp: timestamp.clone(),
                                 received_at: now_iso(),
+                                model: model.clone(),
+                                is_sidechain,
+                                session_id: session_id.clone(),
                             });
                         }
                         _ => {}
@@ -819,7 +878,7 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                 if total > 0 {
                     events.push(Event {
                         id: format!("e{}", app.event_seq.fetch_add(1, Ordering::Relaxed)),
-                        agent_id: "lead".to_string(),
+                        agent_id: agent_id.clone(),
                         event: "token_usage".to_string(),
                         status: "ok".to_string(),
                         latency_ms: None,
@@ -828,6 +887,7 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                             "source": "claude_session",
                             "sessionId": session_id,
                             "model": model,
+                            "isSidechain": is_sidechain,
                             "tokenUsage": {
                                 "inputTokens": input_tokens,
                                 "outputTokens": output_tokens,
@@ -837,6 +897,9 @@ fn parse_session_line(line: &str, app: &App) -> Vec<Event> {
                         }),
                         timestamp: timestamp.clone(),
                         received_at: now_iso(),
+                        model: model.clone(),
+                        is_sidechain,
+                        session_id: session_id.clone(),
                     });
                 }
             }
@@ -864,6 +927,25 @@ fn walk_jsonl_files(dir: &Path) -> Vec<PathBuf> {
                         && sub_path.extension().map(|e| e == "jsonl").unwrap_or(false)
                     {
                         result.push(sub_path);
+                    } else if sub_path.is_dir()
+                        && sub_path
+                            .file_name()
+                            .map(|n| n == "subagents")
+                            .unwrap_or(false)
+                    {
+                        if let Ok(agent_entries) = std::fs::read_dir(&sub_path) {
+                            for agent_entry in agent_entries.flatten() {
+                                let agent_path = agent_entry.path();
+                                if agent_path.is_file()
+                                    && agent_path
+                                        .extension()
+                                        .map(|e| e == "jsonl")
+                                        .unwrap_or(false)
+                                {
+                                    result.push(agent_path);
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -948,6 +1030,9 @@ fn poll_stats_cache(
         }),
         timestamp: now_iso(),
         received_at: now_iso(),
+        model: String::new(),
+        is_sidechain: false,
+        session_id: String::new(),
     })
 }
 
@@ -1123,6 +1208,9 @@ mod tests {
             metadata,
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             received_at: "2025-01-01T00:00:00Z".to_string(),
+            model: String::new(),
+            is_sidechain: false,
+            session_id: String::new(),
         }
     }
 
@@ -1248,6 +1336,9 @@ mod tests {
                 cost_usd: 0.0,
                 last_event: "heartbeat".to_string(),
                 latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -1272,6 +1363,9 @@ mod tests {
                 cost_usd: 0.0,
                 last_event: "warn".to_string(),
                 latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -1294,6 +1388,9 @@ mod tests {
                 cost_usd: 0.0,
                 last_event: "error".to_string(),
                 latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -1328,6 +1425,9 @@ mod tests {
                 cost_usd: 0.5,
                 last_event: "test".to_string(),
                 latency_ms: Some(42),
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
             },
         );
         state.by_agent.insert(
@@ -1343,6 +1443,9 @@ mod tests {
                 cost_usd: 0.1,
                 last_event: "ok".to_string(),
                 latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
             },
         );
         let snap = build_snapshot(&state);
@@ -1651,6 +1754,28 @@ mod tests {
     }
 
     #[test]
+    fn test_walk_jsonl_files_finds_subagent_files() {
+        let dir = unique_tmp_dir("walk_sub");
+        let session = dir.join("session1");
+        let subagents = session.join("subagents");
+        std::fs::create_dir_all(&subagents).unwrap();
+        File::create(session.join("lead.jsonl")).unwrap();
+        File::create(subagents.join("agent-abc.jsonl")).unwrap();
+        File::create(subagents.join("agent-def.jsonl")).unwrap();
+        File::create(subagents.join("notes.txt")).unwrap(); // should be ignored
+
+        let files = walk_jsonl_files(&dir);
+        assert_eq!(files.len(), 3); // lead + 2 sub-agents
+        assert!(files.iter().all(|p| p.extension().unwrap() == "jsonl"));
+        let sub_files: Vec<_> = files
+            .iter()
+            .filter(|p| p.to_string_lossy().contains("subagents"))
+            .collect();
+        assert_eq!(sub_files.len(), 2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn test_walk_jsonl_files_nonexistent_dir() {
         let files = walk_jsonl_files(&std::env::temp_dir().join("ccm_nonexistent_dir_xyz"));
         assert!(files.is_empty());
@@ -1751,6 +1876,62 @@ mod tests {
         let line = r#"{"type":"assistant","message":{"model":"m","content":[{"type":"text","text":""}]},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
         let events = parse_session_line(line, &app);
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_session_line_subagent_uses_agent_id() {
+        let app = make_test_app();
+        let line = r#"{"type":"assistant","agentId":"agent-abc","isSidechain":true,"message":{"model":"claude-haiku-4-5","content":[{"type":"text","text":"hi"}]},"sessionId":"abcdef1234567890","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert_eq!(events[0].agent_id, "agent-abc");
+        assert!(events[0].is_sidechain);
+        assert_eq!(events[0].model, "claude-haiku-4-5");
+        assert_eq!(events[0].session_id, "abcdef1234567890");
+    }
+
+    #[test]
+    fn test_parse_session_line_lead_uses_session_prefix() {
+        let app = make_test_app();
+        let line = r#"{"type":"user","message":{"content":"hi"},"sessionId":"abcdef1234567890","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert_eq!(events[0].agent_id, "lead-abcdef12");
+        assert!(!events[0].is_sidechain);
+        assert_eq!(events[0].session_id, "abcdef1234567890");
+    }
+
+    #[test]
+    fn test_parse_session_line_is_sidechain_false_by_default() {
+        let app = make_test_app();
+        let line = r#"{"type":"user","message":{"content":"hi"},"sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert!(!events[0].is_sidechain);
+    }
+
+    #[test]
+    fn test_parse_history_event_keeps_lead() {
+        let app = make_test_app();
+        let line = r#"{"text":"hello","ts":1700000000,"session_id":"s1"}"#;
+        let evt = parse_history_event(line, &app).unwrap();
+        assert_eq!(evt.agent_id, "lead");
+        assert!(!evt.is_sidechain);
+    }
+
+    #[test]
+    fn test_normalize_incoming_extracts_model_from_metadata() {
+        let app = make_test_app();
+        let payload = json!({
+            "agentId": "agent-x",
+            "event": "test",
+            "metadata": {
+                "model": "claude-opus-4-6",
+                "isSidechain": true,
+                "sessionId": "sess123"
+            }
+        });
+        let evt = normalize_incoming(&payload, &app);
+        assert_eq!(evt.model, "claude-opus-4-6");
+        assert!(evt.is_sidechain);
+        assert_eq!(evt.session_id, "sess123");
     }
 
     #[test]
@@ -2022,6 +2203,9 @@ mod tests {
                 cost_usd: 0.0,
                 last_event: "-".to_string(),
                 latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -2135,6 +2319,16 @@ mod tests {
         broadcast_sse(&app_ref, "trigger_exit".to_string());
 
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_parse_session_line_multibyte_session_id_no_panic() {
+        let app = make_test_app();
+        let line = r#"{"type":"user","message":{"content":"hi"},"sessionId":"한글세션아이디입니다","timestamp":"2025-01-01T00:00:00Z"}"#;
+        let events = parse_session_line(line, &app);
+        assert!(!events.is_empty());
+        // Must not panic on multi-byte chars; prefix should be first 8 chars
+        assert_eq!(events[0].agent_id, "lead-한글세션아이디입");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- 에이전트 목록 테이블에 sessionId 기반 계층형 트리 렌더링 구현
- sub-agent를 lead agent 아래 들여쓰기(└─/├─) 형태로 표시
- UTF-8 멀티바이트 세션 ID 슬라이싱 패닉 수정 및 빈 sessionId 그루핑 버그 수정

## Changes
- `src/main.rs`: `walk_jsonl_files` subagents/ 3단계 탐색, `Event`/`AgentRow`에 `model`/`is_sidechain`/`session_id` 필드 추가, 멀티바이트 UTF-8 패닉 수정
- `public/lib/agent-tree.js` (신규): `buildAgentTree` — sessionId 기준 lead/child 그루핑, 빈 sessionId 시 agentId 폴백
- `public/app.js`: `agentRowHtml`에 `tree-last` 클래스 부여, `extractAgentMeta` 헬퍼로 중복 로직 추출
- `public/styles.css`: `.tree-branch`, `.tree-last`, `.model-badge` 스타일 추가
- `scripts/claude-local-collector.js`: `agentId`/`isSidechain` 필드 추출 반영
- `server.js` / `server-logic.js`: `AgentRow` 필드 전파 및 `tokenTotal`/`costTotalUsd` 집계

## Related Issue
Closes #53

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (82개)
- [x] `npm run check` pass
- [x] JS tests pass (93개)
- [ ] Manual verification of agent tree hierarchy display

🤖 Generated with [Claude Code](https://claude.com/claude-code)