### PR TITLE
feat(ui): 에이전트 이름을 역할+순번 형태로 직관적으로 표시

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 !.claude/skills/
 .DS_Store
 *.swp
+PLAN.md

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "cargo run --release",
     "desktop:start": "electron .",
     "test:js": "node --test 'public/__tests__/**/*.test.js'",
-    "check": "node --check public/app.js && node --check public/lib/workflow.js && node --check public/lib/cards.js && node --check public/lib/palette.js && node --check public/lib/agent-tree.js && node --check public/__tests__/cards.test.js && node --check public/__tests__/palette.test.js && node --check public/__tests__/agent-tree.test.js && node --check public/__tests__/workflow.test.js && node --check desktop/main.js"
+    "check": "node --check public/app.js && node --check public/lib/workflow.js && node --check public/lib/cards.js && node --check public/lib/palette.js && node --check public/lib/agent-tree.js && node --check public/lib/agent-display.js && node --check public/__tests__/cards.test.js && node --check public/__tests__/palette.test.js && node --check public/__tests__/agent-tree.test.js && node --check public/__tests__/workflow.test.js && node --check public/__tests__/agent-display.test.js && node --check desktop/main.js"
   },
   "devDependencies": {
     "electron": "^35.0.0"

--- a/public/__tests__/agent-display.test.js
+++ b/public/__tests__/agent-display.test.js
@@ -1,0 +1,58 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { displayNameFor, resetDisplayNames } from '../lib/agent-display.js';
+
+describe('displayNameFor', () => {
+  beforeEach(() => {
+    resetDisplayNames();
+  });
+
+  it('converts lead prefix to Lead #N', () => {
+    assert.equal(displayNameFor('lead-01660f97'), 'Lead #1');
+  });
+
+  it('assigns incremental numbers for same role', () => {
+    assert.equal(displayNameFor('lead-01660f97'), 'Lead #1');
+    assert.equal(displayNameFor('lead-067ce384'), 'Lead #2');
+  });
+
+  it('converts sub prefix to Sub #N', () => {
+    assert.equal(displayNameFor('sub-067ce384'), 'Sub #1');
+  });
+
+  it('converts agent prefix to Agent #N', () => {
+    assert.equal(displayNameFor('agent-abc'), 'Agent #1');
+  });
+
+  it('converts unknown-agent to Agent #N', () => {
+    assert.equal(displayNameFor('unknown-agent'), 'Agent #1');
+  });
+
+  it('returns same name for repeated calls with same id (idempotent)', () => {
+    const first = displayNameFor('lead-aaa');
+    const second = displayNameFor('lead-aaa');
+    assert.equal(first, second);
+    assert.equal(first, 'Lead #1');
+  });
+
+  it('capitalizes unknown prefixes', () => {
+    assert.equal(displayNameFor('worker-abc123'), 'Worker #1');
+    assert.equal(displayNameFor('worker-def456'), 'Worker #2');
+  });
+
+  it('handles id without hyphen', () => {
+    assert.equal(displayNameFor('standalone'), 'Standalone #1');
+  });
+
+  it('counts roles independently', () => {
+    assert.equal(displayNameFor('lead-aaa'), 'Lead #1');
+    assert.equal(displayNameFor('sub-bbb'), 'Sub #1');
+    assert.equal(displayNameFor('lead-ccc'), 'Lead #2');
+    assert.equal(displayNameFor('sub-ddd'), 'Sub #2');
+  });
+
+  it('shares Agent counter between agent-* and unknown-agent', () => {
+    assert.equal(displayNameFor('agent-abc'), 'Agent #1');
+    assert.equal(displayNameFor('unknown-agent'), 'Agent #2');
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,7 @@ import { recalcWorkflow } from './lib/workflow.js';
 import { buildCardData } from './lib/cards.js';
 import { colorForIndex } from './lib/palette.js';
 import { buildAgentTree } from './lib/agent-tree.js';
+import { displayNameFor } from './lib/agent-display.js';
 
 const cardsRoot = document.getElementById('cards');
 const throughputChart = document.getElementById('throughputChart');
@@ -128,7 +129,7 @@ function agentRowHtml(row, isChild, isLastChild) {
     : '-';
   return `
     <tr${cls}>
-      <td>${prefix}<span class="badge">${escapeHtml(row.agentId)}</span></td>
+      <td>${prefix}<span class="badge" title="${escapeHtml(row.agentId)}">${escapeHtml(displayNameFor(row.agentId))}</span></td>
       <td>${modelBadge}</td>
       <td>${new Date(row.lastSeen).toLocaleTimeString()}</td>
       <td>${Number(row.total) || 0}</td>
@@ -191,7 +192,7 @@ function renderEvents(events) {
       (evt) => `
       <div class="event">
         <span>${new Date(evt.receivedAt).toLocaleTimeString()}</span>
-        <span><strong>${escapeHtml(evt.agentId)}</strong></span>
+        <span title="${escapeHtml(evt.agentId)}"><strong>${escapeHtml(displayNameFor(evt.agentId))}</strong></span>
         <span>${escapeHtml(evt.event)}</span>
         <span>${escapeHtml(evt.message || '')}</span>
         ${statusPill(evt.status)}
@@ -212,7 +213,7 @@ function renderAlerts(alerts = []) {
       (alert) => `
       <div class="event">
         <span>${new Date(alert.createdAt).toLocaleTimeString()}</span>
-        <span><strong>${escapeHtml(alert.agentId)}</strong></span>
+        <span title="${escapeHtml(alert.agentId)}"><strong>${escapeHtml(displayNameFor(alert.agentId))}</strong></span>
         <span>${escapeHtml(alert.event)}</span>
         <span>${escapeHtml(alert.message)}</span>
         ${statusPill(alert.severity)}
@@ -378,7 +379,7 @@ function renderTokenTrendChart(events = []) {
       const last = values[values.length - 1] || 0;
       const x = width.right - 2;
       const y = height.bottom - (last / max) * (height.bottom - height.top);
-      return `<text x="${x}" y="${Math.max(height.top + 8, y - idx * 2).toFixed(2)}" text-anchor="end" font-size="10" fill="${colorForIndex(idx)}">${escapeHtml(agent)}</text>`;
+      return `<text x="${x}" y="${Math.max(height.top + 8, y - idx * 2).toFixed(2)}" text-anchor="end" font-size="10" fill="${colorForIndex(idx)}"><title>${escapeHtml(agent)}</title>${escapeHtml(displayNameFor(agent))}</text>`;
     })
     .join('');
 
@@ -412,7 +413,7 @@ function renderTokenTrendChart(events = []) {
           <svg class="legend-line" viewBox="0 0 22 8" preserveAspectRatio="none">
             <line x1="0" y1="4" x2="22" y2="4" stroke="${color}" stroke-width="${strokeWidth}" />
           </svg>
-          <strong>${escapeHtml(agent)}</strong>
+          <strong title="${escapeHtml(agent)}">${escapeHtml(displayNameFor(agent))}</strong>
           <em>${numberFmt.format(latest)} tok/min</em>
         </span>
       `;
@@ -432,7 +433,7 @@ function populateAgentFilter(agents = []) {
   for (const agent of agents) {
     const opt = document.createElement('option');
     opt.value = agent.agentId;
-    opt.textContent = agent.isSidechain ? `\u21b3 ${agent.agentId}` : agent.agentId;
+    opt.textContent = agent.isSidechain ? `\u21b3 ${displayNameFor(agent.agentId)}` : displayNameFor(agent.agentId);
     agentFilter.appendChild(opt);
   }
   if (ids.includes(prev) || prev === 'all') {

--- a/public/lib/agent-display.js
+++ b/public/lib/agent-display.js
@@ -1,0 +1,59 @@
+/** @type {Map<string, string>} agentId → display name */
+let nameCache = new Map();
+
+/** @type {Map<string, number>} role → next sequence number */
+let roleCounters = new Map();
+
+/**
+ * Extract a normalised role label from an agent ID.
+ *
+ * - "lead-01660f97"  → "Lead"
+ * - "sub-067ce384"   → "Sub"
+ * - "agent-abc"      → "Agent"
+ * - "unknown-agent"  → "Agent"
+ * - "worker-abc123"  → "Worker"
+ * - "standalone"     → "Standalone"
+ *
+ * @param {string} agentId
+ * @returns {string}
+ */
+function extractRole(agentId) {
+  if (agentId === 'unknown-agent') return 'Agent';
+
+  const hyphenIdx = agentId.indexOf('-');
+  const prefix = hyphenIdx === -1 ? agentId : agentId.slice(0, hyphenIdx);
+  if (prefix === 'agent') return 'Agent';
+
+  return prefix.charAt(0).toUpperCase() + prefix.slice(1).toLowerCase();
+}
+
+/**
+ * Convert an agent ID to a human-friendly display name.
+ * The mapping is stable within a page session — the same agentId always
+ * returns the same display name. Sequence numbers are assigned per-role
+ * in first-seen order.
+ *
+ * @param {string} agentId
+ * @returns {string} e.g. "Lead #1", "Sub #2"
+ */
+export function displayNameFor(agentId) {
+  const cached = nameCache.get(agentId);
+  if (cached) return cached;
+
+  const role = extractRole(agentId);
+  const seq = (roleCounters.get(role) || 0) + 1;
+  roleCounters.set(role, seq);
+
+  const name = `${role} #${seq}`;
+  nameCache.set(agentId, name);
+  return name;
+}
+
+/**
+ * Reset all cached display names and counters.
+ * Mainly used for testing.
+ */
+export function resetDisplayNames() {
+  nameCache = new Map();
+  roleCounters = new Map();
+}


### PR DESCRIPTION
## Summary
- `lead-01660f97`, `lead-067ce384` 같은 해시 기반 에이전트 ID를 `Lead #1`, `Lead #2` 형태로 변환하여 대시보드 가독성 향상
- 변환은 프론트엔드에서만 수행하며 서버/백엔드 데이터는 그대로 유지
- hover 시 `title` 속성으로 원본 ID 확인 가능

## Changes
- `public/lib/agent-display.js` 신규 추가: `displayNameFor(agentId)` 함수 — 역할 접두사 추출 + 페이지 세션 동안 순번 유지
- `public/__tests__/agent-display.test.js` 신규 추가: 10개 테스트 케이스 (TDD)
- `public/app.js` 수정: 에이전트 테이블 badge, 이벤트/알림 목록, 필터 드롭다운, 토큰 트렌드 차트 범례에 표시 이름 적용
- `package.json` 수정: `check` 스크립트에 신규 파일 추가
- `.gitignore` 수정: `PLAN.md` 추가

## Related Issue
Closes #62

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] `node --test public/__tests__/*.test.js` — 41개 테스트 통과 확인
- [ ] 대시보드에서 에이전트 이름이 `Lead #1`, `Sub #1` 형태로 표시되는지 확인
- [ ] hover 시 원본 ID가 tooltip으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)