### PR TITLE
feat(ui): 이벤트 클릭 시 metadata 상세 보기 패널 추가

### DIFF
--- a/public/__tests__/events.test.js
+++ b/public/__tests__/events.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { getFilteredEvents } from '../lib/renders/events.js';
+import { getFilteredEvents, renderEventDetail } from '../lib/renders/events.js';
 
 function makeEvt(overrides = {}) {
   return {
@@ -74,5 +74,94 @@ describe('getFilteredEvents', () => {
   it('handles empty events array', () => {
     const result = getFilteredEvents([], { status: 'all', limit: 50, query: '' });
     assert.equal(result.length, 0);
+  });
+});
+
+describe('renderEventDetail', () => {
+  it('renders tool_call with tool name and input JSON', () => {
+    const evt = makeEvt({
+      event: 'tool_call',
+      message: 'Read',
+      metadata: {
+        source: 'claude_session',
+        toolInput: { file_path: '/tmp/test.js' }
+      }
+    });
+    const html = renderEventDetail(evt);
+    assert.ok(html.includes('Read'), 'should include tool name');
+    assert.ok(html.includes('file_path'), 'should include input param key');
+    assert.ok(html.includes('/tmp/test.js'), 'should include input param value');
+    assert.ok(html.includes('event-detail-json'), 'should use json style class');
+  });
+
+  it('renders token_usage with separated token counts', () => {
+    const evt = makeEvt({
+      event: 'token_usage',
+      message: 'tokens +1500',
+      metadata: {
+        source: 'claude_session',
+        tokenUsage: {
+          inputTokens: 1000,
+          outputTokens: 400,
+          cacheReadInputTokens: 100,
+          totalTokens: 1500
+        }
+      }
+    });
+    const html = renderEventDetail(evt);
+    assert.ok(html.includes('1000'), 'should show input tokens');
+    assert.ok(html.includes('400'), 'should show output tokens');
+    assert.ok(html.includes('100'), 'should show cache read tokens');
+    assert.ok(html.includes('1500'), 'should show total tokens');
+    assert.ok(html.includes('event-detail-tokens'), 'should use tokens grid class');
+    assert.ok(html.includes('event-detail-copy'), 'should include copy button');
+  });
+
+  it('renders error event with error highlight', () => {
+    const evt = makeEvt({
+      event: 'api_error',
+      status: 'error',
+      message: 'Rate limit exceeded',
+      metadata: { source: 'claude_session', errorCode: 429 }
+    });
+    const html = renderEventDetail(evt);
+    assert.ok(html.includes('Rate limit exceeded'), 'should show error message');
+    assert.ok(html.includes('event-detail--error'), 'should use error highlight class');
+    assert.ok(html.includes('429'), 'should include metadata details');
+  });
+
+  it('renders generic metadata as formatted JSON', () => {
+    const evt = makeEvt({
+      event: 'session_start',
+      metadata: { source: 'claude_session', sessionId: 'abc-123' }
+    });
+    const html = renderEventDetail(evt);
+    assert.ok(html.includes('abc-123'), 'should include metadata value');
+    assert.ok(html.includes('event-detail-json'), 'should use json style class');
+  });
+
+  it('shows no metadata message when metadata is empty', () => {
+    const evt = makeEvt({ metadata: {} });
+    const html = renderEventDetail(evt);
+    assert.ok(html.includes('No metadata'), 'should show no metadata message');
+  });
+
+  it('escapes HTML in metadata values to prevent XSS', () => {
+    const evt = makeEvt({
+      metadata: { payload: '<script>alert("xss")</script>' }
+    });
+    const html = renderEventDetail(evt);
+    assert.ok(!html.includes('<script>'), 'should not contain raw script tag');
+    assert.ok(html.includes('&lt;script&gt;'), 'should contain escaped script tag');
+  });
+
+  it('includes copy button for tool_call events', () => {
+    const evt = makeEvt({
+      event: 'tool_call',
+      message: 'Bash',
+      metadata: { toolInput: { command: 'ls' } }
+    });
+    const html = renderEventDetail(evt);
+    assert.ok(html.includes('event-detail-copy'), 'should include copy button');
   });
 });

--- a/public/lib/renders/events.js
+++ b/public/lib/renders/events.js
@@ -23,18 +23,95 @@ export function renderEventMeta(total, filtered, el) {
   el.textContent = `events: ${filtered}/${total}`;
 }
 
+export function renderEventDetail(evt) {
+  const meta = evt.metadata;
+  if (!meta || typeof meta !== 'object' || Object.keys(meta).length === 0) {
+    return '<div class="event-detail-inner"><p class="event-detail-empty">No metadata</p></div>';
+  }
+
+  if (evt.event === 'tool_call') {
+    const toolInput = meta.toolInput ?? {};
+    return `<div class="event-detail-inner">
+      <div class="event-detail-label">Tool: <strong>${escapeHtml(evt.message)}</strong></div>
+      <div class="event-detail-label">Input</div>
+      <pre class="event-detail-json">${escapeHtml(JSON.stringify(toolInput, null, 2))}</pre>
+      <button class="event-detail-copy" type="button">Copy JSON</button>
+    </div>`;
+  }
+
+  if (evt.event === 'token_usage') {
+    const usage = meta.tokenUsage ?? {};
+    return `<div class="event-detail-inner">
+      <div class="event-detail-tokens">
+        <div class="event-detail-label">Input</div><div><strong>${usage.inputTokens ?? 0}</strong></div>
+        <div class="event-detail-label">Output</div><div><strong>${usage.outputTokens ?? 0}</strong></div>
+        <div class="event-detail-label">Cache Read</div><div><strong>${usage.cacheReadInputTokens ?? 0}</strong></div>
+        <div class="event-detail-label">Total</div><div><strong>${usage.totalTokens ?? 0}</strong></div>
+      </div>
+      <button class="event-detail-copy" type="button">Copy JSON</button>
+    </div>`;
+  }
+
+  if (evt.status === 'error') {
+    return `<div class="event-detail-inner event-detail--error">
+      <div class="event-detail-label">Error</div>
+      <pre class="event-detail-json">${escapeHtml(evt.message)}\n\n${escapeHtml(JSON.stringify(meta, null, 2))}</pre>
+      <button class="event-detail-copy" type="button">Copy JSON</button>
+    </div>`;
+  }
+
+  return `<div class="event-detail-inner">
+    <pre class="event-detail-json">${escapeHtml(JSON.stringify(meta, null, 2))}</pre>
+    <button class="event-detail-copy" type="button">Copy JSON</button>
+  </div>`;
+}
+
+const eventDataMap = new Map();
+
 export function renderEvents(events, el) {
+  eventDataMap.clear();
+  for (const evt of events) {
+    eventDataMap.set(evt.id, evt);
+  }
+
   el.innerHTML = events
     .map(
       (evt) => `
-      <div class="event">
-        <span>${new Date(evt.receivedAt).toLocaleTimeString()}</span>
-        <span title="${escapeHtml(evt.agentId)}"><strong>${escapeHtml(displayNameFor(evt.agentId))}</strong></span>
-        <span>${escapeHtml(evt.event)}</span>
-        <span>${escapeHtml(evt.message || '')}</span>
-        ${statusPill(evt.status)}
+      <div class="event" data-event-id="${escapeHtml(evt.id)}">
+        <div class="event-summary">
+          <span>${new Date(evt.receivedAt).toLocaleTimeString()}</span>
+          <span title="${escapeHtml(evt.agentId)}"><strong>${escapeHtml(displayNameFor(evt.agentId))}</strong></span>
+          <span>${escapeHtml(evt.event)}</span>
+          <span>${escapeHtml(evt.message || '')}</span>
+          ${statusPill(evt.status)}
+        </div>
+        <div class="event-detail">${renderEventDetail(evt)}</div>
       </div>
     `
     )
     .join('');
+
+  if (!el.dataset.listenerAttached) {
+    el.dataset.listenerAttached = '1';
+    el.addEventListener('click', (e) => {
+      if (e.target.closest('.event-detail-copy')) {
+        const card = e.target.closest('.event[data-event-id]');
+        if (card) {
+          const evt = eventDataMap.get(card.dataset.eventId);
+          if (evt) {
+            const json = JSON.stringify(evt.metadata, null, 2);
+            const btn = e.target.closest('.event-detail-copy');
+            navigator.clipboard.writeText(json).then(() => {
+              btn.textContent = 'Copied!';
+              setTimeout(() => { btn.textContent = 'Copy JSON'; }, 1500);
+            }).catch(() => {});
+          }
+        }
+        return;
+      }
+      const card = e.target.closest('.event[data-event-id]');
+      if (!card) return;
+      card.classList.toggle('event--expanded');
+    });
+  }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -333,21 +333,97 @@ tbody tr:hover td {
 }
 
 .event {
-  display: grid;
-  grid-template-columns: auto auto auto 1fr auto;
-  gap: 8px;
   padding: 9px;
   border-radius: 10px;
   border: 1px solid var(--border-medium);
   background: var(--surface-event);
   font-size: 13px;
-  align-items: center;
+  cursor: pointer;
   transition: background 0.12s ease, border-color 0.12s ease;
 }
 
 .event:hover {
   background: var(--hover-overlay);
   border-color: var(--border);
+}
+
+.event-summary {
+  display: grid;
+  grid-template-columns: auto auto auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.event-detail {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease;
+}
+
+.event--expanded .event-detail {
+  max-height: 800px;
+}
+
+.event-detail-inner {
+  padding-top: 8px;
+  margin-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.event-detail-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+  margin-bottom: 4px;
+}
+
+.event-detail-json {
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 12px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 8px;
+  margin: 4px 0;
+  max-height: 300px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.event-detail-tokens {
+  display: grid;
+  grid-template-columns: auto 1fr auto 1fr;
+  gap: 4px 12px;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.event-detail-copy {
+  font-size: 11px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-card);
+  color: var(--warm-text);
+  cursor: pointer;
+  margin-top: 4px;
+  transition: border-color 0.12s ease;
+}
+
+.event-detail-copy:hover {
+  border-color: var(--warm);
+}
+
+.event-detail--error .event-detail-json {
+  border-color: var(--color-error);
+}
+
+.event-detail-empty {
+  font-size: 12px;
+  opacity: 0.6;
+  margin: 0;
 }
 
 .badge {


### PR DESCRIPTION
## Summary
- 이벤트 카드 클릭 시 metadata 상세 패널 펼침/접힘 토글 기능 추가
- 이벤트 타입(tool_call, token_usage, error)별 맞춤 상세 표시 및 복사 버튼 제공
- XSS 방지를 위한 `escapeHtml` 전면 적용

## Changes
- `public/lib/renders/events.js`: `renderEventDetail()` 함수 추가, `renderEvents`에 이벤트 위임 클릭 핸들러 통합
  - tool_call: 도구명 + toolInput JSON 코드 블록
  - token_usage: input/output/cache/total 토큰 격자 표시
  - error: 에러 강조 스타일 + metadata JSON
  - 복사 버튼: 클릭 시 "Copied!" 피드백 후 1.5초 뒤 복원
- `public/styles.css`: 상세 패널 max-height transition, `.event-detail-json` 독자 스크롤 추가
- `public/__tests__/events.test.js`: `renderEventDetail` 테스트 7케이스 추가 (TDD)

## Related Issue
Closes #71

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)