### PR TITLE
feat(api): POST /api/events 외부 수집 엔드포인트 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Claude 에이전트의 실시간 모니터링 대시보드. Rust 백엔드 + Ele
 
 ## 핵심 기능
 
-- `POST /api/events` 이벤트 수집
 - `GET /api/events` 스냅샷
 - `GET /api/stream` SSE 실시간 스트림
 - `GET /api/alerts` 경고/오류 알림
@@ -34,7 +33,6 @@ cargo run --release
 | `CLAUDE_HOME` | `~/.claude` | Claude 데이터 디렉토리 |
 | `CLAUDE_POLL_MS` | `2500` | 데이터 수집 주기 (ms) |
 | `CLAUDE_BACKFILL_LINES` | `25` | 초기 로드 시 읽을 라인 수 |
-| `MONITOR_API_KEY` | (없음) | 설정 시 `POST /api/events`에 `x-api-key` 헤더 필수 |
 | `PUBLIC_DIR` | `public` | 정적 파일 디렉토리 경로 |
 | `HTTP_READ_TIMEOUT_SEC` | `5` | HTTP 읽기 타임아웃 (초) |
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -488,7 +488,6 @@ mod tests {
             sse_clients: Arc::new(Mutex::new(Vec::new())),
             event_seq: Arc::new(AtomicU64::new(1)),
             public_dir: Arc::new(PathBuf::from("public")),
-            api_key: None,
         }
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,17 +1,15 @@
-use serde_json::{json, Value};
-use std::collections::HashMap;
+use serde_json::json;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::atomic::Ordering;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::Duration;
 
 #[cfg(test)]
 use crate::state::broadcast_sse;
-use crate::state::{append_event, build_snapshot};
-use crate::types::{App, Event, ParsedRequest};
-use crate::utils::{bytes_response, content_type_for, json_response, now_iso, status_norm};
+use crate::state::build_snapshot;
+use crate::types::{App, ParsedRequest};
+use crate::utils::{bytes_response, content_type_for, json_response, now_iso};
 
 pub fn parse_request(stream: &mut TcpStream) -> Option<ParsedRequest> {
     let timeout_secs = std::env::var("HTTP_READ_TIMEOUT_SEC")
@@ -47,103 +45,7 @@ pub fn parse_request(stream: &mut TcpStream) -> Option<ParsedRequest> {
         path = path[..idx].to_string();
     }
 
-    let mut content_length = 0usize;
-    let mut headers = HashMap::new();
-    for line in lines {
-        let lower = line.to_lowercase();
-        if lower.starts_with("content-length:") {
-            let v = line.split(':').nth(1).unwrap_or("0").trim();
-            content_length = v.parse::<usize>().unwrap_or(0);
-        }
-        if let Some((k, v)) = line.split_once(':') {
-            headers.insert(k.trim().to_lowercase(), v.trim().to_string());
-        }
-    }
-    if headers
-        .get("transfer-encoding")
-        .map(|v| v.to_lowercase().contains("chunked"))
-        .unwrap_or(false)
-    {
-        return None;
-    }
-
-    if content_length > 1024 * 1024 {
-        return None;
-    }
-
-    let mut body = data[headers_end..].to_vec();
-    while body.len() < content_length {
-        let n = stream.read(&mut buf).ok()?;
-        if n == 0 {
-            break;
-        }
-        body.extend_from_slice(&buf[..n]);
-    }
-
-    Some(ParsedRequest {
-        method,
-        path,
-        headers,
-        body,
-    })
-}
-
-pub fn normalize_incoming(payload: &Value, app: &App) -> Event {
-    let now = now_iso();
-    let ts = payload
-        .get("timestamp")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| now.clone());
-
-    let status = payload
-        .get("status")
-        .and_then(|v| v.as_str())
-        .map(status_norm)
-        .unwrap_or_else(|| "ok".to_string());
-
-    let meta = payload
-        .get("metadata")
-        .cloned()
-        .unwrap_or_else(|| json!({}));
-
-    Event {
-        id: format!("e{}", app.event_seq.fetch_add(1, Ordering::Relaxed)),
-        agent_id: payload
-            .get("agentId")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown-agent")
-            .to_string(),
-        event: payload
-            .get("event")
-            .and_then(|v| v.as_str())
-            .unwrap_or("heartbeat")
-            .to_string(),
-        status,
-        latency_ms: payload.get("latencyMs").and_then(|v| v.as_i64()),
-        message: payload
-            .get("message")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        model: meta
-            .get("model")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        is_sidechain: meta
-            .get("isSidechain")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        session_id: meta
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        metadata: meta,
-        timestamp: ts,
-        received_at: now,
-    }
+    Some(ParsedRequest { method, path })
 }
 
 pub fn serve_static(app: &App, path: &str) -> Vec<u8> {
@@ -261,35 +163,6 @@ pub fn handle_client(mut stream: TcpStream, app: App) {
                 .push(tx);
             handle_sse(stream, rx, snapshot);
         }
-        ("POST", "/api/events") => {
-            if let Some(expected) = &app.api_key {
-                let provided = req.headers.get("x-api-key").cloned().unwrap_or_default();
-                if &provided != expected {
-                    let _ = stream.write_all(&json_response(
-                        "401 Unauthorized",
-                        &json!({ "error": "Unauthorized" }).to_string(),
-                    ));
-                    return;
-                }
-            }
-
-            let payload: Value = match serde_json::from_slice(&req.body) {
-                Ok(v) => v,
-                Err(_) => {
-                    let _ = stream.write_all(&json_response(
-                        "400 Bad Request",
-                        &json!({ "error": "Invalid JSON" }).to_string(),
-                    ));
-                    return;
-                }
-            };
-
-            let evt = normalize_incoming(&payload, &app);
-            let id = evt.id.clone();
-            append_event(&app, evt);
-            let body = json!({ "accepted": true, "id": id }).to_string();
-            let _ = stream.write_all(&json_response("202 Accepted", &body));
-        }
         ("GET", _) => {
             let resp = serve_static(&app, &req.path);
             let _ = stream.write_all(&resp);
@@ -307,7 +180,6 @@ pub fn handle_client(mut stream: TcpStream, app: App) {
 mod tests {
     use super::*;
     use crate::types::State;
-    use serde_json::json;
     use std::io::Write;
     use std::net::TcpListener;
     use std::path::PathBuf;
@@ -324,7 +196,6 @@ mod tests {
             sse_clients: Arc::new(Mutex::new(Vec::new())),
             event_seq: Arc::new(AtomicU64::new(1)),
             public_dir: Arc::new(path),
-            api_key: None,
         }
     }
 
@@ -357,66 +228,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
-    }
-
-    #[test]
-    fn test_normalize_incoming_full_payload() {
-        let app = make_test_app();
-        let payload = json!({
-            "agentId": "bot-1",
-            "event": "task_complete",
-            "status": "ok",
-            "latencyMs": 123,
-            "message": "done",
-            "timestamp": "2025-06-01T00:00:00Z",
-            "metadata": { "source": "test" }
-        });
-        let evt = normalize_incoming(&payload, &app);
-        assert_eq!(evt.agent_id, "bot-1");
-        assert_eq!(evt.event, "task_complete");
-        assert_eq!(evt.status, "ok");
-        assert_eq!(evt.latency_ms, Some(123));
-        assert_eq!(evt.message, "done");
-        assert_eq!(evt.timestamp, "2025-06-01T00:00:00Z");
-        assert!(evt.id.starts_with('e'));
-    }
-
-    #[test]
-    fn test_normalize_incoming_missing_fields() {
-        let app = make_test_app();
-        let payload = json!({});
-        let evt = normalize_incoming(&payload, &app);
-        assert_eq!(evt.agent_id, "unknown-agent");
-        assert_eq!(evt.event, "heartbeat");
-        assert_eq!(evt.status, "ok");
-        assert_eq!(evt.latency_ms, None);
-        assert_eq!(evt.message, "");
-    }
-
-    #[test]
-    fn test_normalize_incoming_status_normalized() {
-        let app = make_test_app();
-        let payload = json!({ "status": "ERROR" });
-        let evt = normalize_incoming(&payload, &app);
-        assert_eq!(evt.status, "error");
-    }
-
-    #[test]
-    fn test_normalize_incoming_extracts_model_from_metadata() {
-        let app = make_test_app();
-        let payload = json!({
-            "agentId": "agent-x",
-            "event": "test",
-            "metadata": {
-                "model": "claude-opus-4-6",
-                "isSidechain": true,
-                "sessionId": "sess123"
-            }
-        });
-        let evt = normalize_incoming(&payload, &app);
-        assert_eq!(evt.model, "claude-opus-4-6");
-        assert!(evt.is_sidechain);
-        assert_eq!(evt.session_id, "sess123");
     }
 
     #[test]
@@ -507,67 +318,6 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_client_post_events_valid() {
-        let (addr, handle) = spawn_test_server(make_test_app());
-        let body = r#"{"agentId":"a1","event":"test","status":"ok"}"#;
-        let req = format!(
-            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        let resp = http_request(&addr, &req);
-        handle.join().unwrap();
-        assert!(resp.contains("202 Accepted"));
-        assert!(resp.contains("\"accepted\":true"));
-    }
-
-    #[test]
-    fn test_handle_client_post_events_invalid_json() {
-        let (addr, handle) = spawn_test_server(make_test_app());
-        let body = "not json";
-        let req = format!(
-            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        let resp = http_request(&addr, &req);
-        handle.join().unwrap();
-        assert!(resp.contains("400 Bad Request"));
-    }
-
-    #[test]
-    fn test_handle_client_post_events_auth_required() {
-        let mut app = make_test_app();
-        app.api_key = Some("secret123".to_string());
-        let (addr, handle) = spawn_test_server(app);
-        let body = r#"{"agentId":"a1"}"#;
-        let req = format!(
-            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\nX-Api-Key: wrong\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        let resp = http_request(&addr, &req);
-        handle.join().unwrap();
-        assert!(resp.contains("401 Unauthorized"));
-    }
-
-    #[test]
-    fn test_handle_client_post_events_auth_success() {
-        let mut app = make_test_app();
-        app.api_key = Some("secret123".to_string());
-        let (addr, handle) = spawn_test_server(app);
-        let body = r#"{"agentId":"a1"}"#;
-        let req = format!(
-            "POST /api/events HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\nX-Api-Key: secret123\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        let resp = http_request(&addr, &req);
-        handle.join().unwrap();
-        assert!(resp.contains("202 Accepted"));
-    }
-
-    #[test]
     fn test_handle_client_static_file() {
         let dir = unique_tmp_dir("hc_static");
         {
@@ -633,6 +383,17 @@ mod tests {
         broadcast_sse(&app_ref, "trigger_exit".to_string());
 
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_handle_client_post_events_rejected() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(
+            &addr,
+            "POST /api/events HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        );
+        handle.join().unwrap();
+        assert!(resp.contains("405 Method Not Allowed"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,6 @@ fn main() {
                 .unwrap_or_else(|_| ".".to_string());
             PathBuf::from(home).join(".claude")
         });
-    let api_key = std::env::var("MONITOR_API_KEY")
-        .ok()
-        .filter(|v| !v.is_empty());
-
     let listener = std::net::TcpListener::bind(format!("{}:{}", host, port)).expect("bind failed");
 
     let app = App {
@@ -48,7 +44,6 @@ fn main() {
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| PathBuf::from("public")),
         ),
-        api_key,
     };
 
     spawn_claude_collector(app.clone(), claude_home, poll_ms, backfill_lines);

--- a/src/state.rs
+++ b/src/state.rs
@@ -215,7 +215,6 @@ mod tests {
             sse_clients: Arc::new(Mutex::new(Vec::new())),
             event_seq: Arc::new(AtomicU64::new(1)),
             public_dir: Arc::new(PathBuf::from("public")),
-            api_key: None,
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,6 @@ pub struct App {
     pub sse_clients: Arc<Mutex<Vec<Sender<String>>>>,
     pub event_seq: Arc<AtomicU64>,
     pub public_dir: Arc<PathBuf>,
-    pub api_key: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -108,6 +107,4 @@ pub struct Snapshot {
 pub struct ParsedRequest {
     pub method: String,
     pub path: String,
-    pub headers: HashMap<String, String>,
-    pub body: Vec<u8>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,14 +26,6 @@ pub fn bytes_response(code: &str, body: &[u8], content_type: &str) -> Vec<u8> {
     [header.as_bytes(), body].concat()
 }
 
-pub fn status_norm(status: &str) -> String {
-    match status.to_lowercase().as_str() {
-        "error" => "error".to_string(),
-        "warning" => "warning".to_string(),
-        _ => "ok".to_string(),
-    }
-}
-
 pub fn content_type_for(path: &str) -> &'static str {
     if path.ends_with(".html") {
         "text/html; charset=utf-8"
@@ -58,28 +50,6 @@ mod tests {
         assert!(!result.is_empty());
         assert!(result.contains('T'));
         assert!(result.ends_with('Z') || result.contains('+'));
-    }
-
-    #[test]
-    fn test_status_norm_error() {
-        assert_eq!(status_norm("error"), "error");
-        assert_eq!(status_norm("ERROR"), "error");
-        assert_eq!(status_norm("Error"), "error");
-    }
-
-    #[test]
-    fn test_status_norm_warning() {
-        assert_eq!(status_norm("warning"), "warning");
-        assert_eq!(status_norm("WARNING"), "warning");
-        assert_eq!(status_norm("Warning"), "warning");
-    }
-
-    #[test]
-    fn test_status_norm_ok_default() {
-        assert_eq!(status_norm("ok"), "ok");
-        assert_eq!(status_norm(""), "ok");
-        assert_eq!(status_norm("success"), "ok");
-        assert_eq!(status_norm("anything"), "ok");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- 로컬 전용 도구에 불필요한 외부 이벤트 수집 엔드포인트(`POST /api/events`)를 제거
- 관련 인증 로직(`api_key`), 파싱 유틸(`normalize_incoming`, `status_norm`), body 읽기 코드를 함께 정리

## Changes
- `src/http.rs`: `POST /api/events` 핸들러 제거, `normalize_incoming` 제거, `parse_request` 단순화(body/headers 읽기 제거), 테스트 8개 제거 + 1개 추가
- `src/types.rs`: `App.api_key`, `ParsedRequest.headers`, `ParsedRequest.body` 필드 제거
- `src/main.rs`: `MONITOR_API_KEY` 환경변수 파싱 및 App 생성 코드 제거
- `src/state.rs`, `src/collector.rs`: 테스트 `make_test_app`에서 `api_key: None` 제거
- `src/utils.rs`: `status_norm` 함수 및 관련 테스트 3개 제거
- `README.md`: POST 엔드포인트, MONITOR_API_KEY 환경변수 문서 제거

## Related Issue
Closes #66

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (72개)
- [x] `npm run check` pass
- [x] `POST /api/events` 요청 시 `405 Method Not Allowed` 반환 확인 (커버리지 81.96%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)