### PR TITLE
feat(ui): Local Claude Feed 섹션 UI에서 제거

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -11,7 +11,6 @@ import { renderAlerts } from './lib/renders/alerts.js';
 
 const cardsRoot = document.getElementById('cards');
 const workflowRoot = document.getElementById('workflow');
-const sourcesRoot = document.getElementById('sources');
 const agentsBody = document.getElementById('agentsBody');
 const eventsRoot = document.getElementById('events');
 const alertsRoot = document.getElementById('alerts');
@@ -71,25 +70,6 @@ function renderWorkflow(rows = []) {
     .join('');
 }
 
-function renderSources(rows = []) {
-  if (!rows.length) {
-    sourcesRoot.innerHTML = '<article class="workflow-item"><div>No source data</div></article>';
-    return;
-  }
-  sourcesRoot.innerHTML = rows
-    .map(
-      (row) => `
-      <article class="workflow-item">
-        <div><strong>${escapeHtml(row.source)}</strong></div>
-        <div>total: ${Number(row.total) || 0}</div>
-        <div>ok/warn/error: ${Number(row.ok) || 0}/${Number(row.warning) || 0}/${Number(row.error) || 0}</div>
-        <div>last: ${new Date(row.lastSeen).toLocaleTimeString()}</div>
-      </article>
-    `
-    )
-    .join('');
-}
-
 function getFilters() {
   return { status: eventStatusFilter.value, limit: Number(eventLimit.value) || 50, query: eventSearch.value };
 }
@@ -99,7 +79,6 @@ function renderSnapshot(snapshot) {
   renderCards(snapshot.totals);
   populateAgentFilter(snapshot.agents || [], agentFilter);
   renderWorkflow(snapshot.workflowProgress || recalcWorkflow(snapshot.agents));
-  renderSources(snapshot.sources || []);
   renderAgents(snapshot.agents || [], agentsBody, agentFilter.value);
   const allEvents = snapshot.recent || [];
   renderGraphs(allEvents, chartEls, numberFmt);

--- a/public/index.html
+++ b/public/index.html
@@ -42,11 +42,6 @@
       </section>
 
       <section class="panel">
-        <h2>Local Claude Feed</h2>
-        <div class="workflow" id="sources"></div>
-      </section>
-
-      <section class="panel">
         <div class="panel-head">
           <h2>Model 상태</h2>
           <label for="agentFilter">Model Filter</label>


### PR DESCRIPTION
## Summary
- UI에서 내부 구현 디테일인 Local Claude Feed(Source) 섹션을 제거하여 사용자 경험 단순화

## Changes
- `public/index.html`: "Local Claude Feed" `<section>` 블록 제거
- `public/app.js`: `sourcesRoot` DOM 참조, `renderSources()` 함수, `renderSnapshot()` 내 호출부 제거
- 백엔드 source 추적 로직(`state.js`, `src/state.rs`) 및 관련 테스트는 디버깅용으로 유지

## Related Issue
Closes #65

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)