### PR TITLE
feat(ui): Tool Call 시각화 기능 추가 (#70)

### DIFF
--- a/public/__tests__/charts.test.js
+++ b/public/__tests__/charts.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildMinuteBuckets, pathForSeries } from '../lib/renders/charts.js';
+import { buildMinuteBuckets, pathForSeries, buildToolCallStats } from '../lib/renders/charts.js';
 
 describe('buildMinuteBuckets', () => {
   it('returns requested number of buckets', () => {
@@ -82,5 +82,47 @@ describe('pathForSeries', () => {
     const d = pathForSeries([100], { left: 0, right: 100 }, { top: 10, bottom: 90 }, 100);
     // y should be at top (10)
     assert.ok(d.includes('10.00'));
+  });
+});
+
+describe('buildToolCallStats', () => {
+  it('returns empty array for no events', () => {
+    assert.deepEqual(buildToolCallStats([]), []);
+  });
+
+  it('ignores non-tool_call events', () => {
+    const events = [
+      { event: 'assistant_message', message: 'hello' },
+      { event: 'user_message', message: 'hi' }
+    ];
+    assert.deepEqual(buildToolCallStats(events), []);
+  });
+
+  it('counts tool calls by name sorted descending', () => {
+    const events = [
+      { event: 'tool_call', message: 'Read' },
+      { event: 'tool_call', message: 'Bash' },
+      { event: 'tool_call', message: 'Read' },
+      { event: 'tool_call', message: 'Read' },
+      { event: 'tool_call', message: 'Bash' },
+      { event: 'tool_call', message: 'Edit' }
+    ];
+    const stats = buildToolCallStats(events);
+    assert.equal(stats.length, 3);
+    assert.equal(stats[0].name, 'Read');
+    assert.equal(stats[0].count, 3);
+    assert.equal(stats[1].name, 'Bash');
+    assert.equal(stats[1].count, 2);
+    assert.equal(stats[2].name, 'Edit');
+    assert.equal(stats[2].count, 1);
+  });
+
+  it('limits to top 10', () => {
+    const events = [];
+    for (let i = 0; i < 15; i++) {
+      events.push({ event: 'tool_call', message: `tool_${i}` });
+    }
+    const stats = buildToolCallStats(events);
+    assert.equal(stats.length, 10);
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -27,7 +27,9 @@ const chartEls = {
   throughputChart: document.getElementById('throughputChart'),
   throughputTooltip: document.getElementById('throughputTooltip'),
   tokenTrendChart: document.getElementById('tokenTrendChart'),
-  tokenTrendLegend: document.getElementById('tokenTrendLegend')
+  tokenTrendLegend: document.getElementById('tokenTrendLegend'),
+  toolCallChart: document.getElementById('toolCallChart'),
+  toolCallTooltip: document.getElementById('toolCallTooltip')
 };
 
 const numberFmt = new Intl.NumberFormat('ko-KR');
@@ -82,7 +84,7 @@ function renderSnapshot(snapshot) {
   renderWorkflow(snapshot.workflowProgress || recalcWorkflow(snapshot.agents));
   renderAgents(snapshot.agents || [], agentsBody, agentFilter.value);
   const allEvents = snapshot.recent || [];
-  renderGraphs(allEvents, chartEls, numberFmt);
+  renderGraphs(allEvents, chartEls, numberFmt, snapshot.toolCallStats);
   const filteredEvents = getFilteredEvents(allEvents, getFilters());
   renderEvents(filteredEvents, eventsRoot);
   renderEventMeta(allEvents.length, filteredEvents.length, eventMetaEl);
@@ -121,7 +123,7 @@ for (const el of [eventStatusFilter, eventLimit]) {
 eventSearch.addEventListener('input', () => { doSaveFilters(); refilterEvents(); });
 
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-  if (snapshotState) renderGraphs(snapshotState.recent || [], chartEls, numberFmt);
+  if (snapshotState) renderGraphs(snapshotState.recent || [], chartEls, numberFmt, snapshotState.toolCallStats);
 });
 
 applyLoadedFilters();

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,11 @@
             <svg id="tokenTrendChart" class="token-trend-chart" role="img" aria-label="모델별 분당 토큰 사용량 추이 차트" viewBox="0 0 640 220" preserveAspectRatio="none"></svg>
             <div id="tokenTrendLegend" class="token-legend"></div>
           </article>
+          <article class="chart-card">
+            <h3>도구 호출 빈도 (Top 10)</h3>
+            <svg id="toolCallChart" class="tool-call-chart" role="img" aria-label="도구별 호출 빈도 가로 바 차트" viewBox="0 0 640 220" preserveAspectRatio="none"></svg>
+            <div id="toolCallTooltip" class="chart-tooltip" hidden></div>
+          </article>
         </div>
       </section>
 

--- a/public/lib/renders/charts.js
+++ b/public/lib/renders/charts.js
@@ -200,7 +200,79 @@ export function renderTokenTrendChart(events, el, legend, numberFmt) {
     .join('');
 }
 
-export function renderGraphs(events, els, numberFmt) {
+export function buildToolCallStats(events = []) {
+  const counts = {};
+  for (const evt of events) {
+    if (evt.event !== 'tool_call') continue;
+    const name = evt.message || 'unknown';
+    counts[name] = (counts[name] || 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+}
+
+export function renderToolCallChart(stats, el, tooltip) {
+  const top = 10;
+  const bottom = 210;
+  const left = 100;
+  const right = 620;
+  const chartWidth = right - left;
+  const max = Math.max(1, ...stats.map((s) => s.count));
+  const rowH = Math.min(28, (bottom - top) / Math.max(1, stats.length));
+
+  const axisColor = cssVar('--chart-axis');
+  const labelColor = cssVar('--chart-label');
+
+  if (!stats.length) {
+    el.innerHTML = `
+      <title>도구별 호출 빈도 가로 바 차트</title>
+      <text x="${left}" y="${(top + bottom) / 2}" font-size="12" fill="${labelColor}">No tool call data</text>
+    `;
+    return;
+  }
+
+  const bars = stats
+    .map((s, idx) => {
+      const y = top + idx * rowH;
+      const barW = Math.max(2, (s.count / max) * chartWidth);
+      const title = `${escapeHtml(s.name)}: ${s.count} calls`;
+      return `
+        <text x="${left - 6}" y="${y + rowH / 2 + 4}" font-size="11" text-anchor="end" fill="${labelColor}">${escapeHtml(s.name)}</text>
+        <rect class="tool-bar" data-label="${escapeHtml(title)}" x="${left}" y="${y + 2}" width="${barW.toFixed(2)}" height="${(rowH - 4).toFixed(2)}" rx="3" fill="${colorForIndex(idx)}" opacity="0.85"></rect>
+        <text x="${Math.min(left + barW + 4, right - 5)}" y="${y + rowH / 2 + 4}" font-size="10" fill="${labelColor}">${s.count}</text>
+      `;
+    })
+    .join('');
+
+  el.innerHTML = `
+    <title>도구별 호출 빈도 가로 바 차트</title>
+    <line x1="${left}" y1="${top}" x2="${left}" y2="${bottom}" stroke="${axisColor}" stroke-width="1" />
+    ${bars}
+  `;
+
+  el.querySelectorAll('.tool-bar').forEach((bar) => {
+    bar.addEventListener('mouseenter', () => {
+      tooltip.hidden = false;
+      tooltip.textContent = bar.dataset.label || '';
+    });
+    bar.addEventListener('mouseleave', () => {
+      tooltip.hidden = true;
+    });
+    bar.addEventListener('mousemove', (e) => {
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left + 12;
+      const y = e.clientY - rect.top - 8;
+      tooltip.style.left = `${Math.max(8, x)}px`;
+      tooltip.style.top = `${Math.max(8, y)}px`;
+    });
+  });
+}
+
+export function renderGraphs(events, els, numberFmt, toolCallStats) {
   renderThroughputChart(events, els.throughputChart, els.throughputTooltip);
   renderTokenTrendChart(events, els.tokenTrendChart, els.tokenTrendLegend, numberFmt);
+  const stats = toolCallStats || buildToolCallStats(events);
+  renderToolCallChart(stats, els.toolCallChart, els.toolCallTooltip);
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -267,6 +267,14 @@ input[type='search']:focus {
   background: var(--surface-chart);
 }
 
+.tool-call-chart {
+  width: 100%;
+  height: 200px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-chart);
+}
+
 .token-legend {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,9 @@
 use serde_json::json;
 use std::sync::atomic::Ordering;
 
-use crate::types::{AgentRow, AlertRow, App, Event, Snapshot, SourceRow, State, WorkflowRow};
+use crate::types::{
+    AgentRow, AlertRow, App, Event, Snapshot, SourceRow, State, ToolCallStat, WorkflowRow,
+};
 use crate::utils::now_iso;
 
 pub fn workflow_row(state: &State, role_id: &str) -> WorkflowRow {
@@ -55,6 +57,17 @@ pub fn build_snapshot(state: &State) -> Snapshot {
         },
     );
 
+    let mut tool_counts: Vec<(&String, &u64)> = state.tool_use_counts.iter().collect();
+    tool_counts.sort_by(|a, b| b.1.cmp(a.1));
+    let tool_call_stats: Vec<ToolCallStat> = tool_counts
+        .into_iter()
+        .take(10)
+        .map(|(name, count)| ToolCallStat {
+            name: name.clone(),
+            count: *count,
+        })
+        .collect();
+
     Snapshot {
         generated_at: now_iso(),
         totals,
@@ -67,6 +80,7 @@ pub fn build_snapshot(state: &State) -> Snapshot {
             keys.sort();
             keys.iter().map(|k| workflow_row(state, k)).collect()
         },
+        tool_call_stats,
     }
 }
 
@@ -95,6 +109,7 @@ pub fn append_event(app: &App, evt: Event) {
                 model: evt.model.clone(),
                 is_sidechain: evt.is_sidechain,
                 session_id: evt.session_id.clone(),
+                tool_use_counts: std::collections::HashMap::new(),
             });
 
         row.last_seen = evt.received_at.clone();
@@ -112,6 +127,10 @@ pub fn append_event(app: &App, evt: Event) {
             "error" => row.error += 1,
             "warning" => row.warning += 1,
             _ => row.ok += 1,
+        }
+
+        if evt.event == "tool_call" {
+            *row.tool_use_counts.entry(evt.message.clone()).or_insert(0) += 1;
         }
 
         let token_total = evt
@@ -143,6 +162,12 @@ pub fn append_event(app: &App, evt: Event) {
         }
         if cost_delta > 0.0 {
             state.cost_total_usd += cost_delta;
+        }
+        if evt.event == "tool_call" {
+            *state
+                .tool_use_counts
+                .entry(evt.message.clone())
+                .or_insert(0) += 1;
         }
 
         let source = evt
@@ -270,6 +295,7 @@ mod tests {
                 model: String::new(),
                 is_sidechain: false,
                 session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -297,6 +323,7 @@ mod tests {
                 model: String::new(),
                 is_sidechain: false,
                 session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -322,6 +349,7 @@ mod tests {
                 model: String::new(),
                 is_sidechain: false,
                 session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -347,6 +375,7 @@ mod tests {
                 model: String::new(),
                 is_sidechain: false,
                 session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -385,6 +414,7 @@ mod tests {
                 model: String::new(),
                 is_sidechain: false,
                 session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
             },
         );
         state.by_agent.insert(
@@ -403,6 +433,7 @@ mod tests {
                 model: String::new(),
                 is_sidechain: false,
                 session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
             },
         );
         let snap = build_snapshot(&state);
@@ -543,5 +574,91 @@ mod tests {
         drop(rx);
         broadcast_sse(&app, "hello".to_string());
         assert_eq!(app.sse_clients.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_append_event_tracks_tool_use_counts() {
+        let app = make_test_app();
+        let mut evt1 = make_test_event("ok", "tool_call", "a1", json!({}));
+        evt1.message = "Read".to_string();
+        let mut evt2 = make_test_event("ok", "tool_call", "a1", json!({}));
+        evt2.message = "Read".to_string();
+        let mut evt3 = make_test_event("ok", "tool_call", "a1", json!({}));
+        evt3.message = "Bash".to_string();
+        append_event(&app, evt1);
+        append_event(&app, evt2);
+        append_event(&app, evt3);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.tool_use_counts["Read"], 2);
+        assert_eq!(state.tool_use_counts["Bash"], 1);
+    }
+
+    #[test]
+    fn test_append_event_tracks_per_agent_tool_counts() {
+        let app = make_test_app();
+        let mut evt1 = make_test_event("ok", "tool_call", "a1", json!({}));
+        evt1.message = "Read".to_string();
+        let mut evt2 = make_test_event("ok", "tool_call", "a2", json!({}));
+        evt2.message = "Read".to_string();
+        let mut evt3 = make_test_event("ok", "tool_call", "a1", json!({}));
+        evt3.message = "Edit".to_string();
+        append_event(&app, evt1);
+        append_event(&app, evt2);
+        append_event(&app, evt3);
+        let state = app.state.lock().unwrap();
+        let a1 = &state.by_agent["a1"];
+        assert_eq!(a1.tool_use_counts["Read"], 1);
+        assert_eq!(a1.tool_use_counts["Edit"], 1);
+        let a2 = &state.by_agent["a2"];
+        assert_eq!(a2.tool_use_counts["Read"], 1);
+        assert!(!a2.tool_use_counts.contains_key("Edit"));
+    }
+
+    #[test]
+    fn test_build_snapshot_includes_tool_call_stats() {
+        let mut state = State::default();
+        state.tool_use_counts.insert("Read".to_string(), 15);
+        state.tool_use_counts.insert("Bash".to_string(), 10);
+        state.tool_use_counts.insert("Edit".to_string(), 5);
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.tool_call_stats.len(), 3);
+        assert_eq!(snap.tool_call_stats[0].name, "Read");
+        assert_eq!(snap.tool_call_stats[0].count, 15);
+        assert_eq!(snap.tool_call_stats[1].name, "Bash");
+        assert_eq!(snap.tool_call_stats[1].count, 10);
+        assert_eq!(snap.tool_call_stats[2].name, "Edit");
+        assert_eq!(snap.tool_call_stats[2].count, 5);
+    }
+
+    #[test]
+    fn test_build_snapshot_tool_call_stats_top_10_limit() {
+        let mut state = State::default();
+        for i in 0..15 {
+            state
+                .tool_use_counts
+                .insert(format!("tool_{}", i), 100 - i as u64);
+        }
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.tool_call_stats.len(), 10);
+        assert!(snap.tool_call_stats[0].count >= snap.tool_call_stats[9].count);
+    }
+
+    #[test]
+    fn test_build_snapshot_empty_tool_call_stats() {
+        let state = State::default();
+        let snap = build_snapshot(&state);
+        assert!(snap.tool_call_stats.is_empty());
+    }
+
+    #[test]
+    fn test_append_event_non_tool_call_does_not_affect_tool_counts() {
+        let app = make_test_app();
+        append_event(
+            &app,
+            make_test_event("ok", "assistant_message", "a1", json!({})),
+        );
+        append_event(&app, make_test_event("ok", "user_message", "a1", json!({})));
+        let state = app.state.lock().unwrap();
+        assert!(state.tool_use_counts.is_empty());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,6 +47,7 @@ pub struct AgentRow {
     pub model: String,
     pub is_sidechain: bool,
     pub session_id: String,
+    pub tool_use_counts: HashMap<String, u64>,
 }
 
 #[derive(Clone, Serialize)]
@@ -90,6 +91,14 @@ pub struct State {
     pub by_source: HashMap<String, SourceRow>,
     pub token_total: u64,
     pub cost_total_usd: f64,
+    pub tool_use_counts: HashMap<String, u64>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolCallStat {
+    pub name: String,
+    pub count: u64,
 }
 
 #[derive(Serialize)]
@@ -102,6 +111,7 @@ pub struct Snapshot {
     pub recent: Vec<Event>,
     pub alerts: Vec<AlertRow>,
     pub workflow_progress: Vec<WorkflowRow>,
+    pub tool_call_stats: Vec<ToolCallStat>,
 }
 
 pub struct ParsedRequest {


### PR DESCRIPTION
## Summary
- 도구별 호출 빈도를 집계하여 Top 10 가로 바 차트로 시각화
- 백엔드에서 `tool_call` 이벤트를 집계하여 스냅샷에 `toolCallStats` 포함
- TDD 방식으로 Rust(6개)와 JS(4개) 테스트 작성 및 통과

## Changes
- `src/types.rs`: `State`·`AgentRow`에 `tool_use_counts` 필드 추가, `ToolCallStat` 구조체 및 `Snapshot`에 `tool_call_stats` 추가
- `src/state.rs`: `append_event()`에서 `tool_call` 이벤트 집계, `build_snapshot()`에 Top 10 정렬 포함
- `public/lib/renders/charts.js`: `buildToolCallStats()`, `renderToolCallChart()` 함수 추가
- `public/index.html`: 도구 호출 빈도 차트 카드 추가
- `public/app.js`: `toolCallChart`, `toolCallTooltip` DOM 연결, `renderGraphs` 호출 업데이트
- `public/styles.css`: `.tool-call-chart` 스타일 추가
- `public/__tests__/charts.test.js`: `buildToolCallStats` 유닛 테스트 4개 추가

## Related Issue
Closes #70

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (78개 테스트 통과)
- [x] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)