### PR TITLE
feat(ui): 에이전트 실시간 활성 상태 표시기 추가 (#72)

### DIFF
--- a/public/__tests__/agents.test.js
+++ b/public/__tests__/agents.test.js
@@ -116,4 +116,61 @@ describe('agentRowHtml', () => {
     assert.ok(html.includes('&lt;xss&gt;'));
     assert.ok(!html.includes('<xss>'));
   });
+
+  it('includes active activity dot when lastSeen is recent', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const row = {
+      agentId: 'agent-1',
+      model: 'claude-3',
+      lastSeen: new Date(now - 5_000).toISOString(),
+      total: 10,
+      ok: 10,
+      warning: 0,
+      error: 0,
+      tokenTotal: 0,
+      lastEvent: 'Run',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('activity-dot--active'));
+  });
+
+  it('includes idle activity dot when lastSeen is old', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const row = {
+      agentId: 'agent-2',
+      model: '',
+      lastSeen: new Date(now - 300_000).toISOString(),
+      total: 1,
+      ok: 1,
+      warning: 0,
+      error: 0,
+      tokenTotal: 0,
+      lastEvent: 'Done',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('activity-dot--idle'));
+  });
+
+  it('includes recent activity dot between 30s and 2min', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const row = {
+      agentId: 'agent-3',
+      model: '',
+      lastSeen: new Date(now - 60_000).toISOString(),
+      total: 1,
+      ok: 1,
+      warning: 0,
+      error: 0,
+      tokenTotal: 0,
+      lastEvent: 'X',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('activity-dot--recent'));
+  });
 });

--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -36,25 +36,30 @@ describe('buildCardData', () => {
     assert.equal(costCard[1], '0.0000');
   });
 
-  it('returns 7 cards total', () => {
+  it('returns 8 cards total', () => {
     const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
     const cards = buildCardData(totals, numberFmt);
-    assert.equal(cards.length, 7);
+    assert.equal(cards.length, 8);
   });
 
   it('formats non-cost values with numberFmt', () => {
     const totals = { agents: 1000, total: 5000, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt);
-    assert.equal(cards[0][1], '1,000');
-    assert.equal(cards[1][1], '5,000');
+    const agentsCard = cards.find(([l]) => l === 'Agents');
+    const totalCard = cards.find(([l]) => l === 'Total Events');
+    assert.equal(agentsCard[1], '1,000');
+    assert.equal(totalCard[1], '5,000');
   });
 
   it('shows 0 for undefined numeric fields', () => {
     const totals = {};
     const cards = buildCardData(totals, numberFmt);
-    assert.equal(cards[0][1], '0');   // Agents
-    assert.equal(cards[3][1], '0');   // OK
-    assert.equal(cards[6][1], '0.0000'); // Cost (USD)
+    const agentsCard = cards.find(([l]) => l === 'Agents');
+    const okCard = cards.find(([l]) => l === 'OK');
+    const costCard = cards.find(([l]) => l === 'Cost (USD)');
+    assert.equal(agentsCard[1], '0');
+    assert.equal(okCard[1], '0');
+    assert.equal(costCard[1], '0.0000');
   });
 
   it('assigns ok type to OK card', () => {
@@ -86,5 +91,32 @@ describe('buildCardData', () => {
       const card = cards.find(([l]) => l === label);
       assert.equal(card[2], 'neutral', `${label} should have neutral type`);
     }
+  });
+
+  it('includes Active card with ok type when activeAgents > 0', () => {
+    const totals = { agents: 2, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt, 2);
+    const activeCard = cards.find(([label]) => label === 'Active');
+    assert.ok(activeCard, 'Active card should exist');
+    assert.equal(activeCard[1], '2');
+    assert.equal(activeCard[2], 'ok');
+  });
+
+  it('includes Active card with neutral type when activeAgents is 0', () => {
+    const totals = { agents: 2, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt, 0);
+    const activeCard = cards.find(([label]) => label === 'Active');
+    assert.ok(activeCard, 'Active card should exist');
+    assert.equal(activeCard[1], '0');
+    assert.equal(activeCard[2], 'neutral');
+  });
+
+  it('defaults activeAgents to 0 when not provided', () => {
+    const totals = { agents: 1, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const activeCard = cards.find(([label]) => label === 'Active');
+    assert.ok(activeCard, 'Active card should exist');
+    assert.equal(activeCard[1], '0');
+    assert.equal(activeCard[2], 'neutral');
   });
 });

--- a/public/__tests__/utils.test.js
+++ b/public/__tests__/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { escapeHtml, statusPill, normalizeText } from '../lib/utils.js';
+import { escapeHtml, statusPill, normalizeText, getActivityStatus, activityDotHtml, countActiveAgents } from '../lib/utils.js';
 
 describe('escapeHtml', () => {
   it('escapes & < > " \'', () => {
@@ -52,5 +52,100 @@ describe('normalizeText', () => {
   it('handles null and undefined', () => {
     assert.equal(normalizeText(null), '');
     assert.equal(normalizeText(undefined), '');
+  });
+});
+
+describe('getActivityStatus', () => {
+  it('returns active when lastSeen is within 30 seconds', () => {
+    const now = Date.now();
+    const lastSeen = new Date(now - 10_000).toISOString();
+    assert.equal(getActivityStatus(lastSeen, now), 'active');
+  });
+
+  it('returns recent when lastSeen is between 30s and 2min', () => {
+    const now = Date.now();
+    const lastSeen = new Date(now - 60_000).toISOString();
+    assert.equal(getActivityStatus(lastSeen, now), 'recent');
+  });
+
+  it('returns idle when lastSeen is over 2 minutes ago', () => {
+    const now = Date.now();
+    const lastSeen = new Date(now - 180_000).toISOString();
+    assert.equal(getActivityStatus(lastSeen, now), 'idle');
+  });
+
+  it('returns recent at exactly 30 seconds boundary', () => {
+    const now = Date.now();
+    const lastSeen = new Date(now - 30_000).toISOString();
+    assert.equal(getActivityStatus(lastSeen, now), 'recent');
+  });
+
+  it('returns idle at exactly 120 seconds boundary', () => {
+    const now = Date.now();
+    const lastSeen = new Date(now - 120_000).toISOString();
+    assert.equal(getActivityStatus(lastSeen, now), 'idle');
+  });
+
+  it('returns idle when lastSeen is null', () => {
+    assert.equal(getActivityStatus(null, Date.now()), 'idle');
+  });
+
+  it('returns idle when lastSeen is undefined', () => {
+    assert.equal(getActivityStatus(undefined, Date.now()), 'idle');
+  });
+});
+
+describe('activityDotHtml', () => {
+  it('returns span with activity-dot class for active status', () => {
+    const html = activityDotHtml('active');
+    assert.ok(html.includes('activity-dot'));
+    assert.ok(html.includes('activity-dot--active'));
+  });
+
+  it('returns span with recent modifier', () => {
+    const html = activityDotHtml('recent');
+    assert.ok(html.includes('activity-dot--recent'));
+  });
+
+  it('returns span with idle modifier', () => {
+    const html = activityDotHtml('idle');
+    assert.ok(html.includes('activity-dot--idle'));
+  });
+
+  it('escapes malicious status to prevent XSS', () => {
+    const html = activityDotHtml('<script>');
+    assert.ok(!html.includes('<script>'));
+    assert.ok(html.includes('&lt;script&gt;'));
+  });
+});
+
+describe('countActiveAgents', () => {
+  it('counts agents with lastSeen within 30 seconds', () => {
+    const now = Date.now();
+    const agents = [
+      { lastSeen: new Date(now - 5_000).toISOString() },
+      { lastSeen: new Date(now - 10_000).toISOString() },
+      { lastSeen: new Date(now - 60_000).toISOString() }
+    ];
+    assert.equal(countActiveAgents(agents, now), 2);
+  });
+
+  it('returns 0 when no agents are active', () => {
+    const now = Date.now();
+    const agents = [
+      { lastSeen: new Date(now - 120_000).toISOString() },
+      { lastSeen: new Date(now - 300_000).toISOString() }
+    ];
+    assert.equal(countActiveAgents(agents, now), 0);
+  });
+
+  it('returns 0 for empty array', () => {
+    assert.equal(countActiveAgents([], Date.now()), 0);
+  });
+
+  it('excludes agent at exactly 30 seconds boundary', () => {
+    const now = Date.now();
+    const agents = [{ lastSeen: new Date(now - 30_000).toISOString() }];
+    assert.equal(countActiveAgents(agents, now), 0);
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,6 @@
 import { recalcWorkflow } from './lib/workflow.js';
 import { buildCardData } from './lib/cards.js';
-import { escapeHtml, statusPill } from './lib/utils.js';
+import { escapeHtml, statusPill, getActivityStatus, activityDotHtml, countActiveAgents } from './lib/utils.js';
 import { applyIncrementalEvent } from './lib/state.js';
 import { saveFilters, loadFilters } from './lib/persistence.js';
 import { connectStream, loadSnapshot } from './lib/connection.js';
@@ -51,8 +51,9 @@ function queueRender() {
   });
 }
 
-function renderCards(totals) {
-  const cards = buildCardData(totals, numberFmt);
+function renderCards(totals, agents = []) {
+  const activeAgents = countActiveAgents(agents);
+  const cards = buildCardData(totals, numberFmt, activeAgents);
   cardsRoot.innerHTML = cards
     .map(
       ([label, value, type]) =>
@@ -62,11 +63,12 @@ function renderCards(totals) {
 }
 
 function renderWorkflow(rows = []) {
+  const now = Date.now();
   workflowRoot.innerHTML = rows
     .map(
       (row) => `
       <article class="workflow-item">
-        <div><strong>${escapeHtml(row.roleId)}</strong></div>
+        <div>${activityDotHtml(getActivityStatus(row.lastSeen, now))}<strong>${escapeHtml(row.roleId)}</strong></div>
         <div>${statusPill(row.status)}</div>
         <div>events: ${Number(row.total) || 0}</div>
         <div>last: ${escapeHtml(row.lastEvent)}</div>
@@ -82,7 +84,7 @@ function getFilters() {
 
 function renderSnapshot(snapshot) {
   snapshotState = snapshot;
-  renderCards(snapshot.totals);
+  renderCards(snapshot.totals, snapshot.agents || []);
   populateAgentFilter(snapshot.agents || [], agentFilter);
   renderWorkflow(snapshot.workflowProgress || recalcWorkflow(snapshot.agents));
   renderAgents(snapshot.agents || [], agentsBody, agentFilter.value);
@@ -147,3 +149,10 @@ connectStream({
   },
   onFallback() { loadSnapshot().then((snapshot) => renderSnapshot(snapshot)).catch(console.error); }
 });
+
+setInterval(() => {
+  if (!snapshotState || renderQueued) return;
+  renderCards(snapshotState.totals, snapshotState.agents || []);
+  renderWorkflow(snapshotState.workflowProgress || recalcWorkflow(snapshotState.agents));
+  renderAgents(snapshotState.agents || [], agentsBody, agentFilter.value);
+}, 1000);

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,6 +1,7 @@
-export function buildCardData(totals, numberFmt) {
+export function buildCardData(totals, numberFmt, activeAgents = 0) {
   return [
     ['Agents', numberFmt.format(totals.agents || 0), 'neutral'],
+    ['Active', numberFmt.format(activeAgents), activeAgents > 0 ? 'ok' : 'neutral'],
     ['Total Events', numberFmt.format(totals.total || 0), 'neutral'],
     ['Total Tokens', numberFmt.format(totals.tokenTotal || 0), 'neutral'],
     ['OK', numberFmt.format(totals.ok || 0), 'ok'],

--- a/public/lib/renders/agents.js
+++ b/public/lib/renders/agents.js
@@ -1,19 +1,20 @@
-import { escapeHtml } from '../utils.js';
+import { escapeHtml, getActivityStatus, activityDotHtml } from '../utils.js';
 import { displayNameFor } from '../agent-display.js';
 import { buildAgentTree } from '../agent-tree.js';
 
 const numberFmt = new Intl.NumberFormat('ko-KR');
 
-export function agentRowHtml(row, isChild, isLastChild) {
+export function agentRowHtml(row, isChild, isLastChild, now = Date.now()) {
   const prefix = isChild ? '<span class="tree-branch"></span>' : '';
   const classes = [isChild && 'tree-child', isLastChild && 'tree-last'].filter(Boolean).join(' ');
   const cls = classes ? ` class="${classes}"` : '';
   const modelBadge = row.model
     ? `<span class="model-badge">${escapeHtml(row.model)}</span>`
     : '-';
+  const dot = activityDotHtml(getActivityStatus(row.lastSeen, now));
   return `
     <tr${cls}>
-      <td>${prefix}<span class="badge" title="${escapeHtml(row.agentId)}">${escapeHtml(displayNameFor(row.agentId))}</span></td>
+      <td>${prefix}${dot}<span class="badge" title="${escapeHtml(row.agentId)}">${escapeHtml(displayNameFor(row.agentId))}</span></td>
       <td>${modelBadge}</td>
       <td>${new Date(row.lastSeen).toLocaleTimeString()}</td>
       <td>${Number(row.total) || 0}</td>

--- a/public/lib/utils.js
+++ b/public/lib/utils.js
@@ -19,3 +19,20 @@ export function statusPill(status) {
 export function normalizeText(v) {
   return String(v || '').toLowerCase();
 }
+
+export function getActivityStatus(lastSeen, now = Date.now()) {
+  if (!lastSeen) return 'idle';
+  const elapsed = now - new Date(lastSeen).getTime();
+  if (elapsed < 30_000) return 'active';
+  if (elapsed < 120_000) return 'recent';
+  return 'idle';
+}
+
+export function activityDotHtml(status) {
+  const safe = escapeHtml(status);
+  return `<span class="activity-dot activity-dot--${safe}" aria-label="${safe}"></span>`;
+}
+
+export function countActiveAgents(agents, now = Date.now()) {
+  return agents.filter((a) => now - new Date(a.lastSeen).getTime() < 30_000).length;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -599,6 +599,35 @@ tbody tr:hover td {
   }
 }
 
+/* ── Activity dot styles ── */
+.activity-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.activity-dot--active {
+  background: var(--color-ok);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.activity-dot--recent {
+  background: var(--color-warning);
+}
+
+.activity-dot--idle {
+  background: var(--warm-text);
+  opacity: 0.35;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
+}
+
 /* ── Agent tree styles ── */
 tr.tree-child td:first-child {
   padding-left: 28px;


### PR DESCRIPTION
## Summary
- 에이전트 테이블과 Workflow 카드에 `lastSeen` 기반 활성 상태 점(dot) 표시 추가
- Summary Card에 실시간 활성 에이전트 수("Active") 카드 추가
- 1초 타이머로 SSE 이벤트와 독립적으로 상태 갱신

## Changes
- `public/lib/utils.js`: `getActivityStatus`, `activityDotHtml`, `countActiveAgents` 함수 추가
- `public/lib/renders/agents.js`: 에이전트 행에 activity dot 삽입 (`now` 파라미터로 테스트 가능)
- `public/lib/cards.js`: `buildCardData`에 `activeAgents` 파라미터 및 "Active" 카드 추가 (총 8개)
- `public/app.js`: `renderCards`·`renderWorkflow` 통합, `connectStream` 이후에 1초 `setInterval` 배치, 중복 렌더링 방지(`renderQueued` 가드)
- `public/styles.css`: `.activity-dot` 스타일 및 `@keyframes pulse` 애니메이션 추가

**활성 상태 기준:**
| 상태 | 조건 | 표시 |
|------|------|------|
| active | 30초 이내 | 초록 점 + 펄스 애니메이션 |
| recent | 30초~2분 | 노란 점 |
| idle | 2분 이상 | 회색 점 |

## Related Issue
Closes #72

## Test Plan
- [x] `npm run check` pass
- [x] `cargo test` pass (78개)
- [x] `node --test public/__tests__/*.test.js` pass (150개)
- [ ] 브라우저에서 에이전트 테이블 activity dot 표시 확인
- [ ] 1초마다 dot 상태 갱신 확인
- [ ] Workflow 카드 dot 표시 확인
- [ ] Summary Card "Active" 수 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)