### PR TITLE
feat(ui): Summary Cards를 핵심 지표 4개로 축소

### DIFF
--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -5,6 +5,28 @@ import { buildCardData } from '../lib/cards.js';
 const numberFmt = new Intl.NumberFormat('ko-KR');
 
 describe('buildCardData', () => {
+  it('returns 4 cards total', () => {
+    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
+    const cards = buildCardData(totals, numberFmt);
+    assert.equal(cards.length, 4);
+  });
+
+  it('includes only Active, Error, Total Tokens, Cost (USD) cards', () => {
+    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05 };
+    const cards = buildCardData(totals, numberFmt, 1);
+    const labels = cards.map(([label]) => label);
+    assert.deepEqual(labels, ['Active', 'Error', 'Total Tokens', 'Cost (USD)']);
+  });
+
+  it('does not include removed cards', () => {
+    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05 };
+    const cards = buildCardData(totals, numberFmt);
+    const labels = cards.map(([label]) => label);
+    for (const removed of ['Agents', 'Total Events', 'OK', 'Warning']) {
+      assert.ok(!labels.includes(removed), `${removed} card should not exist`);
+    }
+  });
+
   it('includes Cost (USD) card with 4 decimal places', () => {
     const totals = {
       agents: 2,
@@ -36,58 +58,44 @@ describe('buildCardData', () => {
     assert.equal(costCard[1], '0.0000');
   });
 
-  it('returns 8 cards total', () => {
-    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
+  it('formats token values with numberFmt', () => {
+    const totals = { agents: 1, total: 5000, tokenTotal: 50000, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt);
-    assert.equal(cards.length, 8);
-  });
-
-  it('formats non-cost values with numberFmt', () => {
-    const totals = { agents: 1000, total: 5000, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const agentsCard = cards.find(([l]) => l === 'Agents');
-    const totalCard = cards.find(([l]) => l === 'Total Events');
-    assert.equal(agentsCard[1], '1,000');
-    assert.equal(totalCard[1], '5,000');
+    const tokenCard = cards.find(([l]) => l === 'Total Tokens');
+    assert.equal(tokenCard[1], '50,000');
   });
 
   it('shows 0 for undefined numeric fields', () => {
     const totals = {};
     const cards = buildCardData(totals, numberFmt);
-    const agentsCard = cards.find(([l]) => l === 'Agents');
-    const okCard = cards.find(([l]) => l === 'OK');
+    const activeCard = cards.find(([l]) => l === 'Active');
+    const errorCard = cards.find(([l]) => l === 'Error');
+    const tokenCard = cards.find(([l]) => l === 'Total Tokens');
     const costCard = cards.find(([l]) => l === 'Cost (USD)');
-    assert.equal(agentsCard[1], '0');
-    assert.equal(okCard[1], '0');
+    assert.equal(activeCard[1], '0');
+    assert.equal(errorCard[1], '0');
+    assert.equal(tokenCard[1], '0');
     assert.equal(costCard[1], '0.0000');
   });
 
-  it('assigns ok type to OK card', () => {
-    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 1, warning: 0, error: 0, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const okCard = cards.find(([label]) => label === 'OK');
-    assert.equal(okCard[2], 'ok');
-  });
-
-  it('assigns warning type to Warning card', () => {
-    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 1, error: 0, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const warningCard = cards.find(([label]) => label === 'Warning');
-    assert.equal(warningCard[2], 'warning');
-  });
-
-  it('assigns error type to Error card', () => {
+  it('assigns error type to Error card when error > 0', () => {
     const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 1, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt);
     const errorCard = cards.find(([label]) => label === 'Error');
     assert.equal(errorCard[2], 'error');
   });
 
-  it('assigns neutral type to non-status cards', () => {
+  it('assigns neutral type to Error card when error is 0', () => {
+    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const errorCard = cards.find(([label]) => label === 'Error');
+    assert.equal(errorCard[2], 'neutral');
+  });
+
+  it('assigns neutral type to Total Tokens and Cost cards', () => {
     const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
     const cards = buildCardData(totals, numberFmt);
-    const neutralLabels = ['Agents', 'Total Events', 'Total Tokens', 'Cost (USD)'];
-    for (const label of neutralLabels) {
+    for (const label of ['Total Tokens', 'Cost (USD)']) {
       const card = cards.find(([l]) => l === label);
       assert.equal(card[2], 'neutral', `${label} should have neutral type`);
     }

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,12 +1,8 @@
 export function buildCardData(totals, numberFmt, activeAgents = 0) {
   return [
-    ['Agents', numberFmt.format(totals.agents || 0), 'neutral'],
     ['Active', numberFmt.format(activeAgents), activeAgents > 0 ? 'ok' : 'neutral'],
-    ['Total Events', numberFmt.format(totals.total || 0), 'neutral'],
+    ['Error', numberFmt.format(totals.error || 0), (totals.error || 0) > 0 ? 'error' : 'neutral'],
     ['Total Tokens', numberFmt.format(totals.tokenTotal || 0), 'neutral'],
-    ['OK', numberFmt.format(totals.ok || 0), 'ok'],
-    ['Warning', numberFmt.format(totals.warning || 0), 'warning'],
-    ['Error', numberFmt.format(totals.error || 0), 'error'],
     ['Cost (USD)', Number(totals.costTotalUsd || 0).toFixed(4), 'neutral']
   ];
 }


### PR DESCRIPTION
## Summary
- 8개 Summary Cards를 actionable한 핵심 지표 4개로 축소
- Error 카드가 에러 수에 따라 `error`/`neutral` 타입을 동적으로 반영하도록 개선

## Changes
- `public/lib/cards.js`: `buildCardData()`에서 `Agents`, `Total Events`, `OK`, `Warning` 카드 제거. 최종 카드: `Active`, `Error`, `Total Tokens`, `Cost (USD)`
- `public/lib/cards.js`: `Error` 카드 타입을 `error > 0 ? 'error' : 'neutral'`로 변경 (Active 카드와 동일한 상태 반영 패턴)
- `public/__tests__/cards.test.js`: 새 카드 구조에 맞게 테스트 전면 수정 (13→14개 테스트)

## Related Issue
Closes #69

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (78 tests)
- [x] `npm run check` pass
- [x] `node --test public/__tests__/cards.test.js` pass (14 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)