### PR TITLE
feat(api): 첫 user_message 기반 워크플로우 display_name 표시

### DIFF
--- a/public/__tests__/workflow.test.js
+++ b/public/__tests__/workflow.test.js
@@ -61,7 +61,8 @@ describe('recalcWorkflow', () => {
       total: 3,
       lastEvent: 'ping',
       lastSeen: '2026-02-28T12:00:00Z',
-      model: 'claude-opus-4-6'
+      model: 'claude-opus-4-6',
+      displayName: ''
     });
   });
 
@@ -82,5 +83,21 @@ describe('recalcWorkflow', () => {
     const agent = { agentId: 'x', error: 1, warning: 5, total: 10, lastEvent: 'e', lastSeen: 't' };
     const result = recalcWorkflow([agent]);
     assert.equal(result[0].status, 'blocked');
+  });
+
+  it('passes displayName from agent row', () => {
+    const agents = [
+      { agentId: 'a1', error: 0, warning: 0, total: 1, lastEvent: 'e', lastSeen: 't', displayName: 'Fix login bug' }
+    ];
+    const result = recalcWorkflow(agents);
+    assert.equal(result[0].displayName, 'Fix login bug');
+  });
+
+  it('defaults displayName to empty string when missing', () => {
+    const agents = [
+      { agentId: 'a1', error: 0, warning: 0, total: 1, lastEvent: 'e', lastSeen: 't' }
+    ];
+    const result = recalcWorkflow(agents);
+    assert.equal(result[0].displayName, '');
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -68,7 +68,7 @@ function renderWorkflow(rows = []) {
     .map(
       (row) => `
       <article class="workflow-item">
-        <div>${activityDotHtml(getActivityStatus(row.lastSeen, now))}<strong>${escapeHtml(row.roleId)}</strong></div>
+        <div>${activityDotHtml(getActivityStatus(row.lastSeen, now))}<strong>${escapeHtml(row.displayName || row.roleId)}</strong></div>
         <div>${statusPill(row.status)}</div>
         <div>events: ${Number(row.total) || 0}</div>
         <div>last: ${escapeHtml(row.lastEvent)}</div>

--- a/public/lib/renders/agents.js
+++ b/public/lib/renders/agents.js
@@ -14,7 +14,7 @@ export function agentRowHtml(row, isChild, isLastChild, now = Date.now()) {
   const dot = activityDotHtml(getActivityStatus(row.lastSeen, now));
   return `
     <tr${cls}>
-      <td>${prefix}${dot}<span class="badge" title="${escapeHtml(row.agentId)}">${escapeHtml(displayNameFor(row.agentId, row.model))}</span></td>
+      <td>${prefix}${dot}<span class="badge" title="${escapeHtml(row.agentId)}">${escapeHtml(row.displayName || displayNameFor(row.agentId, row.model))}</span></td>
       <td>${modelBadge}</td>
       <td>${new Date(row.lastSeen).toLocaleTimeString()}</td>
       <td>${Number(row.total) || 0}</td>

--- a/public/lib/workflow.js
+++ b/public/lib/workflow.js
@@ -8,7 +8,8 @@ export function recalcWorkflow(agents = []) {
       total: row.total,
       lastEvent: row.lastEvent,
       lastSeen: row.lastSeen,
-      model: row.model || ''
+      model: row.model || '',
+      displayName: row.displayName || ''
     };
   });
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -25,6 +25,7 @@ pub fn workflow_row(state: &State, role_id: &str) -> WorkflowRow {
             total: row.total,
             last_event: row.last_event.clone(),
             last_seen: Some(row.last_seen.clone()),
+            display_name: row.display_name.clone(),
         }
     } else {
         WorkflowRow {
@@ -34,6 +35,7 @@ pub fn workflow_row(state: &State, role_id: &str) -> WorkflowRow {
             total: 0,
             last_event: "-".to_string(),
             last_seen: None,
+            display_name: String::new(),
         }
     }
 }
@@ -110,6 +112,7 @@ pub fn append_event(app: &App, evt: Event) {
                 is_sidechain: evt.is_sidechain,
                 session_id: evt.session_id.clone(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             });
 
         row.last_seen = evt.received_at.clone();
@@ -123,6 +126,19 @@ pub fn append_event(app: &App, evt: Event) {
         if !evt.session_id.is_empty() {
             row.session_id = evt.session_id.clone();
         }
+        if (evt.event == "user_message" || evt.event == "user_request")
+            && row.display_name.is_empty()
+            && !evt.message.is_empty()
+        {
+            let mut chars = evt.message.chars();
+            let truncated: String = chars.by_ref().take(40).collect();
+            if chars.next().is_some() {
+                row.display_name = format!("{}...", truncated);
+            } else {
+                row.display_name = truncated;
+            }
+        }
+
         match evt.status.as_str() {
             "error" => row.error += 1,
             "warning" => row.warning += 1,
@@ -296,6 +312,7 @@ mod tests {
                 is_sidechain: false,
                 session_id: String::new(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -324,6 +341,7 @@ mod tests {
                 is_sidechain: false,
                 session_id: String::new(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -350,6 +368,7 @@ mod tests {
                 is_sidechain: false,
                 session_id: String::new(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -376,6 +395,7 @@ mod tests {
                 is_sidechain: false,
                 session_id: String::new(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             },
         );
         let row = workflow_row(&state, "agent-1");
@@ -415,6 +435,7 @@ mod tests {
                 is_sidechain: false,
                 session_id: String::new(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             },
         );
         state.by_agent.insert(
@@ -434,6 +455,7 @@ mod tests {
                 is_sidechain: false,
                 session_id: String::new(),
                 tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
             },
         );
         let snap = build_snapshot(&state);
@@ -660,5 +682,78 @@ mod tests {
         append_event(&app, make_test_event("ok", "user_message", "a1", json!({})));
         let state = app.state.lock().unwrap();
         assert!(state.tool_use_counts.is_empty());
+    }
+
+    #[test]
+    fn test_append_event_sets_display_name_on_first_user_message() {
+        let app = make_test_app();
+        let mut evt = make_test_event("ok", "user_message", "a1", json!({}));
+        evt.message = "Fix the login bug".to_string();
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.by_agent["a1"].display_name, "Fix the login bug");
+    }
+
+    #[test]
+    fn test_append_event_sets_display_name_on_user_request() {
+        let app = make_test_app();
+        let mut evt = make_test_event("ok", "user_request", "a1", json!({}));
+        evt.message = "Add dark mode".to_string();
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.by_agent["a1"].display_name, "Add dark mode");
+    }
+
+    #[test]
+    fn test_append_event_truncates_display_name_at_40_chars() {
+        let app = make_test_app();
+        let mut evt = make_test_event("ok", "user_message", "a1", json!({}));
+        evt.message = "This is a very long message that exceeds forty characters limit".to_string();
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(
+            state.by_agent["a1"].display_name,
+            "This is a very long message that exceeds..."
+        );
+    }
+
+    #[test]
+    fn test_append_event_does_not_overwrite_existing_display_name() {
+        let app = make_test_app();
+        let mut evt1 = make_test_event("ok", "user_message", "a1", json!({}));
+        evt1.message = "First message".to_string();
+        append_event(&app, evt1);
+        let mut evt2 = make_test_event("ok", "user_message", "a1", json!({}));
+        evt2.message = "Second message".to_string();
+        append_event(&app, evt2);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.by_agent["a1"].display_name, "First message");
+    }
+
+    #[test]
+    fn test_workflow_row_includes_display_name() {
+        let mut state = State::default();
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                total: 1,
+                ok: 1,
+                warning: 0,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "ping".to_string(),
+                latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
+                display_name: "Fix login bug".to_string(),
+            },
+        );
+        let row = workflow_row(&state, "agent-1");
+        assert_eq!(row.display_name, "Fix login bug");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,6 +48,7 @@ pub struct AgentRow {
     pub is_sidechain: bool,
     pub session_id: String,
     pub tool_use_counts: HashMap<String, u64>,
+    pub display_name: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -81,6 +82,7 @@ pub struct WorkflowRow {
     pub total: u64,
     pub last_event: String,
     pub last_seen: Option<String>,
+    pub display_name: String,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- `AgentRow`, `WorkflowRow`에 `display_name` 필드 추가
- 첫 `user_message` / `user_request` 이벤트 수신 시 에이전트 이름을 메시지 내용으로 설정 (최대 40자 + "...")
- 프론트엔드 Workflow 카드 및 에이전트 테이블에 `displayName` 우선 표시, 없으면 기존 ID/역할명 fallback

## Changes
- `src/types.rs` — `AgentRow`, `WorkflowRow`에 `display_name: String` 필드 추가
- `src/state.rs` — `append_event()`에 display_name 설정 로직 추가 (단일 패스 이터레이터), `workflow_row()`에 display_name 전달, 단위 테스트 5개 추가
- `public/lib/workflow.js` — `recalcWorkflow()`에 `displayName` 필드 전달
- `public/app.js` — `renderWorkflow()`에서 `displayName || roleId` fallback 표시
- `public/lib/renders/agents.js` — `agentRowHtml()`에서 `displayName` 우선 표시
- `public/__tests__/workflow.test.js` — displayName 전달 테스트 2개 추가

## Related Issue
Closes #94

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (83 tests)
- [x] `npm run check` pass
- [x] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)