### PR TITLE
feat(api): workflow 상태 로직을 시간 기반으로 개선 (#93)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }

--- a/public/__tests__/workflow.test.js
+++ b/public/__tests__/workflow.test.js
@@ -33,15 +33,17 @@ describe('recalcWorkflow', () => {
     assert.equal(result[0].status, 'at-risk');
   });
 
-  it('maps agent with total > 0 (no errors/warnings) to running status', () => {
+  it('maps agent with total > 0 and recent lastSeen to running status', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 10_000; // 10초 후
     const agents = [
-      { agentId: 'coder', error: 0, warning: 0, total: 7, lastEvent: 'code', lastSeen: '2026-01-01T00:00:00Z' }
+      { agentId: 'coder', error: 0, warning: 0, total: 7, lastEvent: 'code', lastSeen }
     ];
-    const result = recalcWorkflow(agents);
+    const result = recalcWorkflow(agents, now);
     assert.equal(result[0].status, 'running');
   });
 
-  it('maps agent with total 0 to idle status', () => {
+  it('maps agent with total 0 and no lastSeen to idle status', () => {
     const agents = [
       { agentId: 'idle-agent', error: 0, warning: 0, total: 0, lastEvent: '-', lastSeen: null }
     ];
@@ -50,29 +52,33 @@ describe('recalcWorkflow', () => {
   });
 
   it('preserves all agent fields in output', () => {
+    const lastSeen = '2026-02-28T12:00:00Z';
+    const now = new Date(lastSeen).getTime() + 5_000; // 5초 후
     const agents = [
-      { agentId: 'alpha', error: 0, warning: 0, total: 3, lastEvent: 'ping', lastSeen: '2026-02-28T12:00:00Z', model: 'claude-opus-4-6' }
+      { agentId: 'alpha', error: 0, warning: 0, total: 3, lastEvent: 'ping', lastSeen, model: 'claude-opus-4-6' }
     ];
-    const result = recalcWorkflow(agents);
+    const result = recalcWorkflow(agents, now);
     assert.deepStrictEqual(result[0], {
       roleId: 'alpha',
       active: true,
       status: 'running',
       total: 3,
       lastEvent: 'ping',
-      lastSeen: '2026-02-28T12:00:00Z',
+      lastSeen,
       model: 'claude-opus-4-6',
       displayName: ''
     });
   });
 
   it('handles multiple agents with different statuses', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 5_000;
     const agents = [
-      { agentId: 'a', error: 1, warning: 0, total: 5, lastEvent: 'e1', lastSeen: 't1' },
-      { agentId: 'b', error: 0, warning: 2, total: 3, lastEvent: 'e2', lastSeen: 't2' },
-      { agentId: 'c', error: 0, warning: 0, total: 1, lastEvent: 'e3', lastSeen: 't3' }
+      { agentId: 'a', error: 1, warning: 0, total: 5, lastEvent: 'e1', lastSeen },
+      { agentId: 'b', error: 0, warning: 2, total: 3, lastEvent: 'e2', lastSeen },
+      { agentId: 'c', error: 0, warning: 0, total: 1, lastEvent: 'e3', lastSeen }
     ];
-    const result = recalcWorkflow(agents);
+    const result = recalcWorkflow(agents, now);
     assert.equal(result.length, 3);
     assert.equal(result[0].status, 'blocked');
     assert.equal(result[1].status, 'at-risk');
@@ -80,7 +86,7 @@ describe('recalcWorkflow', () => {
   });
 
   it('status priority: error > warning > total > idle', () => {
-    const agent = { agentId: 'x', error: 1, warning: 5, total: 10, lastEvent: 'e', lastSeen: 't' };
+    const agent = { agentId: 'x', error: 1, warning: 5, total: 10, lastEvent: 'e', lastSeen: '2026-01-01T00:00:00Z' };
     const result = recalcWorkflow([agent]);
     assert.equal(result[0].status, 'blocked');
   });
@@ -99,5 +105,65 @@ describe('recalcWorkflow', () => {
     ];
     const result = recalcWorkflow(agents);
     assert.equal(result[0].displayName, '');
+  });
+
+  // --- 시간 기반 상태 테스트 ---
+
+  it('completed when last_seen over 2 minutes', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 180_000; // 3분 후
+    const agents = [
+      { agentId: 'done', error: 0, warning: 0, total: 5, lastEvent: 'msg', lastSeen }
+    ];
+    const result = recalcWorkflow(agents, now);
+    assert.equal(result[0].status, 'completed');
+  });
+
+  it('idle when last_seen between 30s and 2min', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 60_000; // 60초 후
+    const agents = [
+      { agentId: 'paused', error: 0, warning: 0, total: 5, lastEvent: 'msg', lastSeen }
+    ];
+    const result = recalcWorkflow(agents, now);
+    assert.equal(result[0].status, 'idle');
+  });
+
+  it('running when last_seen under 30s', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 10_000; // 10초 후
+    const agents = [
+      { agentId: 'active', error: 0, warning: 0, total: 3, lastEvent: 'msg', lastSeen }
+    ];
+    const result = recalcWorkflow(agents, now);
+    assert.equal(result[0].status, 'running');
+  });
+
+  it('blocked overrides time', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 600_000; // 10분 후
+    const agents = [
+      { agentId: 'err', error: 1, warning: 0, total: 5, lastEvent: 'err', lastSeen }
+    ];
+    const result = recalcWorkflow(agents, now);
+    assert.equal(result[0].status, 'blocked');
+  });
+
+  it('at-risk overrides time', () => {
+    const lastSeen = '2026-01-01T00:00:00Z';
+    const now = new Date(lastSeen).getTime() + 600_000; // 10분 후
+    const agents = [
+      { agentId: 'warn', error: 0, warning: 2, total: 5, lastEvent: 'warn', lastSeen }
+    ];
+    const result = recalcWorkflow(agents, now);
+    assert.equal(result[0].status, 'at-risk');
+  });
+
+  it('invalid lastSeen string falls back to idle', () => {
+    const agents = [
+      { agentId: 'bad', error: 0, warning: 0, total: 5, lastEvent: 'msg', lastSeen: 'invalid-date' }
+    ];
+    const result = recalcWorkflow(agents);
+    assert.equal(result[0].status, 'idle');
   });
 });

--- a/public/lib/workflow.js
+++ b/public/lib/workflow.js
@@ -1,6 +1,16 @@
-export function recalcWorkflow(agents = []) {
+export function recalcWorkflow(agents = [], now = Date.now()) {
   return agents.map((row) => {
-    const status = row.error > 0 ? 'blocked' : row.warning > 0 ? 'at-risk' : row.total > 0 ? 'running' : 'idle';
+    const raw = row.lastSeen ? now - new Date(row.lastSeen).getTime() : null;
+    const elapsed = raw !== null && !isNaN(raw) ? raw : null;
+    const status = row.error > 0
+      ? 'blocked'
+      : row.warning > 0
+        ? 'at-risk'
+        : elapsed !== null && elapsed < 30_000 && row.total > 0
+          ? 'running'
+          : elapsed !== null && elapsed >= 120_000
+            ? 'completed'
+            : 'idle';
     return {
       roleId: row.agentId,
       active: true,

--- a/public/styles.css
+++ b/public/styles.css
@@ -486,6 +486,13 @@ tbody tr:hover td {
   opacity: 0.6;
 }
 
+.status-pill[data-status='completed'] {
+  border-style: dashed;
+  border-color: var(--color-ok);
+  color: var(--color-ok);
+  opacity: 0.5;
+}
+
 .status-pill[data-status='connected'] {
   border-color: var(--color-ok);
   color: var(--color-ok);

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,21 +1,38 @@
 use serde_json::json;
 use std::sync::atomic::Ordering;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::types::{
     AgentRow, AlertRow, App, Event, Snapshot, SourceRow, State, ToolCallStat, WorkflowRow,
 };
 use crate::utils::now_iso;
 
+fn elapsed_secs_from(last_seen: &str, now: OffsetDateTime) -> Option<i64> {
+    let parsed = OffsetDateTime::parse(last_seen, &Rfc3339).ok()?;
+    Some((now - parsed).whole_seconds())
+}
+
 pub fn workflow_row(state: &State, role_id: &str) -> WorkflowRow {
+    workflow_row_at(state, role_id, OffsetDateTime::now_utc())
+}
+
+fn workflow_row_at(state: &State, role_id: &str, now: OffsetDateTime) -> WorkflowRow {
     if let Some(row) = state.by_agent.get(role_id) {
+        let elapsed = elapsed_secs_from(&row.last_seen, now);
+
         let status = if row.error > 0 {
             "blocked"
         } else if row.warning > 0 {
             "at-risk"
-        } else if row.total > 0 {
-            "running"
         } else {
-            "idle"
+            match elapsed {
+                Some(s) if s < 30 && row.total > 0 => "running",
+                Some(s) if s >= 120 => "completed",
+                Some(_) => "idle",
+                None if row.total > 0 => "running",
+                None => "idle",
+            }
         };
 
         WorkflowRow {
@@ -292,14 +309,19 @@ mod tests {
         assert!(row.last_seen.is_none());
     }
 
+    fn parse_time(s: &str) -> OffsetDateTime {
+        OffsetDateTime::parse(s, &Rfc3339).unwrap()
+    }
+
     #[test]
     fn test_workflow_row_running() {
         let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
         state.by_agent.insert(
             "agent-1".to_string(),
             AgentRow {
                 agent_id: "agent-1".to_string(),
-                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                last_seen: last_seen.to_string(),
                 total: 5,
                 ok: 5,
                 warning: 0,
@@ -315,7 +337,9 @@ mod tests {
                 display_name: String::new(),
             },
         );
-        let row = workflow_row(&state, "agent-1");
+        // 10초 후 → running
+        let now = parse_time(last_seen) + time::Duration::seconds(10);
+        let row = workflow_row_at(&state, "agent-1", now);
         assert!(row.active);
         assert_eq!(row.status, "running");
         assert_eq!(row.total, 5);
@@ -344,6 +368,7 @@ mod tests {
                 display_name: String::new(),
             },
         );
+        // at-risk는 시간 무관
         let row = workflow_row(&state, "agent-1");
         assert_eq!(row.status, "at-risk");
     }
@@ -371,18 +396,20 @@ mod tests {
                 display_name: String::new(),
             },
         );
+        // blocked는 시간 무관
         let row = workflow_row(&state, "agent-1");
         assert_eq!(row.status, "blocked");
     }
 
     #[test]
-    fn test_workflow_row_idle_with_zero_total() {
+    fn test_workflow_row_completed_when_zero_total() {
         let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
         state.by_agent.insert(
             "agent-1".to_string(),
             AgentRow {
                 agent_id: "agent-1".to_string(),
-                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                last_seen: last_seen.to_string(),
                 total: 0,
                 ok: 0,
                 warning: 0,
@@ -398,9 +425,161 @@ mod tests {
                 display_name: String::new(),
             },
         );
-        let row = workflow_row(&state, "agent-1");
+        // 3분 경과, total=0 → completed
+        let now = parse_time(last_seen) + time::Duration::seconds(180);
+        let row = workflow_row_at(&state, "agent-1", now);
         assert!(row.active);
+        assert_eq!(row.status, "completed");
+    }
+
+    #[test]
+    fn test_workflow_row_completed_when_last_seen_over_2min() {
+        let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: last_seen.to_string(),
+                total: 5,
+                ok: 5,
+                warning: 0,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "done".to_string(),
+                latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
+            },
+        );
+        // 3분 경과 → completed
+        let now = parse_time(last_seen) + time::Duration::seconds(180);
+        let row = workflow_row_at(&state, "agent-1", now);
+        assert_eq!(row.status, "completed");
+    }
+
+    #[test]
+    fn test_workflow_row_idle_when_last_seen_30s_to_2min() {
+        let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: last_seen.to_string(),
+                total: 5,
+                ok: 5,
+                warning: 0,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "msg".to_string(),
+                latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
+            },
+        );
+        // 60초 경과 → idle
+        let now = parse_time(last_seen) + time::Duration::seconds(60);
+        let row = workflow_row_at(&state, "agent-1", now);
         assert_eq!(row.status, "idle");
+    }
+
+    #[test]
+    fn test_workflow_row_running_when_last_seen_recent() {
+        let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: last_seen.to_string(),
+                total: 3,
+                ok: 3,
+                warning: 0,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "ping".to_string(),
+                latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
+            },
+        );
+        // 5초 경과 → running
+        let now = parse_time(last_seen) + time::Duration::seconds(5);
+        let row = workflow_row_at(&state, "agent-1", now);
+        assert_eq!(row.status, "running");
+    }
+
+    #[test]
+    fn test_workflow_row_blocked_overrides_time() {
+        let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: last_seen.to_string(),
+                total: 5,
+                ok: 3,
+                warning: 1,
+                error: 1,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "err".to_string(),
+                latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
+            },
+        );
+        // 10분 경과해도 error면 blocked
+        let now = parse_time(last_seen) + time::Duration::seconds(600);
+        let row = workflow_row_at(&state, "agent-1", now);
+        assert_eq!(row.status, "blocked");
+    }
+
+    #[test]
+    fn test_workflow_row_at_risk_overrides_time() {
+        let mut state = State::default();
+        let last_seen = "2025-01-01T00:00:00Z";
+        state.by_agent.insert(
+            "agent-1".to_string(),
+            AgentRow {
+                agent_id: "agent-1".to_string(),
+                last_seen: last_seen.to_string(),
+                total: 5,
+                ok: 3,
+                warning: 2,
+                error: 0,
+                token_total: 0,
+                cost_usd: 0.0,
+                last_event: "warn".to_string(),
+                latency_ms: None,
+                model: String::new(),
+                is_sidechain: false,
+                session_id: String::new(),
+                tool_use_counts: std::collections::HashMap::new(),
+                display_name: String::new(),
+            },
+        );
+        // 10분 경과해도 warning이면 at-risk
+        let now = parse_time(last_seen) + time::Duration::seconds(600);
+        let row = workflow_row_at(&state, "agent-1", now);
+        assert_eq!(row.status, "at-risk");
     }
 
     #[test]
@@ -755,5 +934,22 @@ mod tests {
         );
         let row = workflow_row(&state, "agent-1");
         assert_eq!(row.display_name, "Fix login bug");
+    }
+
+    #[test]
+    fn test_elapsed_secs_from_valid_iso() {
+        let iso = now_iso();
+        let now = OffsetDateTime::now_utc();
+        let result = elapsed_secs_from(&iso, now);
+        assert!(result.is_some());
+        let secs = result.unwrap();
+        assert!(secs >= 0 && secs < 2);
+    }
+
+    #[test]
+    fn test_elapsed_secs_from_invalid_returns_none() {
+        let now = OffsetDateTime::now_utc();
+        assert!(elapsed_secs_from("not-a-date", now).is_none());
+        assert!(elapsed_secs_from("", now).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- `last_seen` 시간 기반으로 workflow 상태를 `running` / `idle` / `completed`로 구분
- 백엔드(`src/state.rs`)와 프론트엔드(`public/lib/workflow.js`) 로직 통합
- `completed` 상태 전용 status pill CSS 스타일 추가

## Changes
- `src/state.rs`: `elapsed_secs_from()` 헬퍼 + `workflow_row_at()` 시간 기반 분기 (30초/2분 임계값)
- `public/lib/workflow.js`: `recalcWorkflow(agents, now)` — `now` 파라미터 추가, `isNaN` 방어 로직 포함
- `public/__tests__/workflow.test.js`: 기존 테스트 `now` 파라미터 주입 + 시간 기반 케이스 6개 추가
- `public/styles.css`: `.status-pill[data-status='completed']` 스타일 추가
- `Cargo.toml`: `time` 크레이트 `parsing` 피처 추가

## Related Issue
Closes #93

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (90 tests)
- [x] `npm run check` pass
- [x] `node --test public/__tests__/workflow.test.js` pass (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)