### PR TITLE
feat(ui): workflow 목록 필터링 및 완료 세션 접기 기능 추가

### DIFF
--- a/public/__tests__/persistence.test.js
+++ b/public/__tests__/persistence.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { saveFilters, loadFilters } from '../lib/persistence.js';
+import { saveFilters, loadFilters, saveToggle, loadToggle } from '../lib/persistence.js';
 
 // minimal localStorage mock
 function createStorageMock() {
@@ -42,5 +42,44 @@ describe('loadFilters', () => {
     const storage = createStorageMock();
     storage.setItem(KEY, '{broken');
     assert.equal(loadFilters(KEY, storage), null);
+  });
+});
+
+describe('saveToggle', () => {
+  it('stores boolean true as "true"', () => {
+    const storage = createStorageMock();
+    saveToggle('toggle_key', true, storage);
+    assert.equal(storage.getItem('toggle_key'), 'true');
+  });
+
+  it('stores boolean false as "false"', () => {
+    const storage = createStorageMock();
+    saveToggle('toggle_key', false, storage);
+    assert.equal(storage.getItem('toggle_key'), 'false');
+  });
+});
+
+describe('loadToggle', () => {
+  it('returns false when key is missing', () => {
+    const storage = createStorageMock();
+    assert.equal(loadToggle('toggle_key', storage), false);
+  });
+
+  it('returns true when stored value is "true"', () => {
+    const storage = createStorageMock();
+    storage.setItem('toggle_key', 'true');
+    assert.equal(loadToggle('toggle_key', storage), true);
+  });
+
+  it('returns false when stored value is "false"', () => {
+    const storage = createStorageMock();
+    storage.setItem('toggle_key', 'false');
+    assert.equal(loadToggle('toggle_key', storage), false);
+  });
+
+  it('returns false for unexpected value', () => {
+    const storage = createStorageMock();
+    storage.setItem('toggle_key', 'maybe');
+    assert.equal(loadToggle('toggle_key', storage), false);
   });
 });

--- a/public/__tests__/workflow.test.js
+++ b/public/__tests__/workflow.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { recalcWorkflow } from '../lib/workflow.js';
+import { recalcWorkflow, splitWorkflow } from '../lib/workflow.js';
 
 describe('recalcWorkflow', () => {
   it('returns empty array when agents is empty', () => {
@@ -165,5 +165,60 @@ describe('recalcWorkflow', () => {
     ];
     const result = recalcWorkflow(agents);
     assert.equal(result[0].status, 'idle');
+  });
+});
+
+describe('splitWorkflow', () => {
+  it('separates active and completed sessions', () => {
+    const rows = [
+      { roleId: 'a', status: 'running', lastSeen: '2026-01-01T00:00:10Z' },
+      { roleId: 'b', status: 'completed', lastSeen: '2026-01-01T00:00:05Z' },
+      { roleId: 'c', status: 'blocked', lastSeen: '2026-01-01T00:00:08Z' },
+      { roleId: 'd', status: 'idle', lastSeen: '2026-01-01T00:00:03Z' },
+      { roleId: 'e', status: 'at-risk', lastSeen: '2026-01-01T00:00:07Z' },
+    ];
+    const { active, completed } = splitWorkflow(rows);
+    assert.deepStrictEqual(active.map(r => r.roleId), ['a', 'c', 'e']);
+    assert.deepStrictEqual(completed.map(r => r.roleId), ['b', 'd']);
+  });
+
+  it('sorts each group by lastSeen descending', () => {
+    const rows = [
+      { roleId: 'a', status: 'running', lastSeen: '2026-01-01T00:00:01Z' },
+      { roleId: 'b', status: 'running', lastSeen: '2026-01-01T00:00:10Z' },
+      { roleId: 'c', status: 'completed', lastSeen: '2026-01-01T00:00:05Z' },
+      { roleId: 'd', status: 'completed', lastSeen: '2026-01-01T00:00:09Z' },
+    ];
+    const { active, completed } = splitWorkflow(rows);
+    assert.deepStrictEqual(active.map(r => r.roleId), ['b', 'a']);
+    assert.deepStrictEqual(completed.map(r => r.roleId), ['d', 'c']);
+  });
+
+  it('limits completed to 20', () => {
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      roleId: `c${i}`,
+      status: 'completed',
+      lastSeen: `2026-01-01T00:00:${String(i).padStart(2, '0')}Z`,
+    }));
+    const { completed } = splitWorkflow(rows);
+    assert.equal(completed.length, 20);
+    // newest first
+    assert.equal(completed[0].roleId, 'c24');
+  });
+
+  it('returns empty arrays when no rows', () => {
+    const { active, completed } = splitWorkflow([]);
+    assert.deepStrictEqual(active, []);
+    assert.deepStrictEqual(completed, []);
+  });
+
+  it('handles rows with null lastSeen', () => {
+    const rows = [
+      { roleId: 'a', status: 'running', lastSeen: '2026-01-01T00:00:10Z' },
+      { roleId: 'b', status: 'idle', lastSeen: null },
+    ];
+    const { active, completed } = splitWorkflow(rows);
+    assert.equal(active.length, 1);
+    assert.equal(completed.length, 1);
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,8 @@
-import { recalcWorkflow } from './lib/workflow.js';
+import { recalcWorkflow, splitWorkflow } from './lib/workflow.js';
 import { buildCardData } from './lib/cards.js';
 import { escapeHtml, statusPill, getActivityStatus, activityDotHtml, countActiveAgents } from './lib/utils.js';
 import { applyIncrementalEvent } from './lib/state.js';
-import { saveFilters, loadFilters } from './lib/persistence.js';
+import { saveFilters, loadFilters, saveToggle, loadToggle } from './lib/persistence.js';
 import { connectStream, loadSnapshot } from './lib/connection.js';
 import { renderGraphs } from './lib/renders/charts.js';
 import { getFilteredEvents, renderEventMeta, renderEvents } from './lib/renders/events.js';
@@ -35,10 +35,15 @@ const chartEls = {
   toolCallTooltip: document.getElementById('toolCallTooltip')
 };
 
+const workflowToggle = document.getElementById('workflowToggle');
+const workflowCompletedRoot = document.getElementById('workflowCompleted');
+
 const numberFmt = new Intl.NumberFormat('ko-KR');
 let snapshotState = null;
 let renderQueued = false;
 const storageKey = 'agent_monitor_event_filters_v1';
+const WORKFLOW_TOGGLE_KEY = 'agent_monitor_workflow_toggle_v1';
+let showCompleted = loadToggle(WORKFLOW_TOGGLE_KEY);
 
 function queueRender() {
   if (renderQueued) return;
@@ -62,20 +67,27 @@ function renderCards(totals, agents = []) {
     .join('');
 }
 
+function renderWorkflowItem(row, now) {
+  return `<article class="workflow-item">
+    <div>${activityDotHtml(getActivityStatus(row.lastSeen, now))}<strong>${escapeHtml(row.displayName || row.roleId)}</strong></div>
+    <div>${statusPill(row.status)}</div>
+    <div>events: ${Number(row.total) || 0}</div>
+    <div>last: ${escapeHtml(row.lastEvent)}</div>
+  </article>`;
+}
+
 function renderWorkflow(rows = []) {
   const now = Date.now();
-  workflowRoot.innerHTML = rows
-    .map(
-      (row) => `
-      <article class="workflow-item">
-        <div>${activityDotHtml(getActivityStatus(row.lastSeen, now))}<strong>${escapeHtml(row.displayName || row.roleId)}</strong></div>
-        <div>${statusPill(row.status)}</div>
-        <div>events: ${Number(row.total) || 0}</div>
-        <div>last: ${escapeHtml(row.lastEvent)}</div>
-      </article>
-    `
-    )
-    .join('');
+  const { active, completed } = splitWorkflow(rows);
+
+  workflowRoot.innerHTML = active.length > 0
+    ? active.map((row) => renderWorkflowItem(row, now)).join('')
+    : '<p class="workflow-empty">활성 세션 없음</p>';
+
+  workflowToggle.textContent = `완료된 세션 (${completed.length})`;
+  workflowToggle.classList.toggle('active', showCompleted);
+  workflowCompletedRoot.classList.toggle('open', showCompleted);
+  workflowCompletedRoot.innerHTML = completed.map((row) => renderWorkflowItem(row, now)).join('');
 }
 
 function getFilters() {
@@ -117,6 +129,12 @@ function refilterEvents() {
   renderEvents(filtered, eventsRoot);
   renderEventMeta(allEvents.length, filtered.length, eventMetaEl);
 }
+
+workflowToggle.addEventListener('click', () => {
+  showCompleted = !showCompleted;
+  saveToggle(WORKFLOW_TOGGLE_KEY, showCompleted);
+  queueRender();
+});
 
 agentFilter.addEventListener('change', () => {
   if (snapshotState) {

--- a/public/index.html
+++ b/public/index.html
@@ -52,8 +52,12 @@
       </section>
 
       <section class="panel">
-        <h2>Workflow 진행 현황</h2>
+        <div class="panel-head">
+          <h2>Workflow 진행 현황</h2>
+          <button id="workflowToggle" class="workflow-toggle-btn">완료된 세션 (0)</button>
+        </div>
         <div class="workflow" id="workflow"></div>
+        <div id="workflowCompleted" class="workflow-completed"></div>
       </section>
 
       <section class="panel">

--- a/public/lib/persistence.js
+++ b/public/lib/persistence.js
@@ -11,3 +11,11 @@ export function loadFilters(storageKey, storage = localStorage) {
     return null;
   }
 }
+
+export function saveToggle(storageKey, value, storage = localStorage) {
+  storage.setItem(storageKey, String(value));
+}
+
+export function loadToggle(storageKey, storage = localStorage) {
+  return storage.getItem(storageKey) === 'true';
+}

--- a/public/lib/workflow.js
+++ b/public/lib/workflow.js
@@ -1,3 +1,27 @@
+const ACTIVE_STATUSES = new Set(['running', 'blocked', 'at-risk']);
+const MAX_COMPLETED = 20;
+
+function sortByLastSeenDesc(a, b) {
+  const aTime = a.lastSeen || '';
+  const bTime = b.lastSeen || '';
+  return bTime < aTime ? -1 : bTime > aTime ? 1 : 0;
+}
+
+export function splitWorkflow(rows = []) {
+  const active = [];
+  const completed = [];
+  for (const row of rows) {
+    if (ACTIVE_STATUSES.has(row.status)) {
+      active.push(row);
+    } else {
+      completed.push(row);
+    }
+  }
+  active.sort(sortByLastSeenDesc);
+  completed.sort(sortByLastSeenDesc);
+  return { active, completed: completed.slice(0, MAX_COMPLETED) };
+}
+
 export function recalcWorkflow(agents = [], now = Date.now()) {
   return agents.map((row) => {
     const raw = row.lastSeen ? now - new Date(row.lastSeen).getTime() : null;

--- a/public/styles.css
+++ b/public/styles.css
@@ -232,6 +232,49 @@ input[type='search']:focus {
   box-shadow: 0 3px 12px var(--shadow-hover-subtle);
 }
 
+.workflow-toggle-btn {
+  border: 1px solid var(--border);
+  background: var(--paper);
+  color: var(--warm-text);
+  border-radius: 8px;
+  padding: 4px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.workflow-toggle-btn:hover {
+  border-color: var(--warm);
+}
+
+.workflow-toggle-btn.active {
+  border-color: var(--warm);
+  background: var(--hover-overlay);
+}
+
+.workflow-completed {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, margin-top 0.3s ease;
+}
+
+.workflow-completed.open {
+  max-height: 2000px;
+  margin-top: 8px;
+  overflow-y: auto;
+}
+
+.workflow-empty {
+  text-align: center;
+  padding: 16px;
+  opacity: 0.6;
+  font-size: 13px;
+  grid-column: 1 / -1;
+}
+
 .charts-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/src/state.rs
+++ b/src/state.rs
@@ -95,9 +95,17 @@ pub fn build_snapshot(state: &State) -> Snapshot {
         recent: state.recent.iter().take(300).cloned().collect(),
         alerts: state.alerts.iter().take(20).cloned().collect(),
         workflow_progress: {
-            let mut keys: Vec<&String> = state.by_agent.keys().collect();
-            keys.sort();
-            keys.iter().map(|k| workflow_row(state, k)).collect()
+            let mut rows: Vec<WorkflowRow> = state
+                .by_agent
+                .keys()
+                .map(|k| workflow_row(state, k))
+                .collect();
+            rows.sort_by(|a, b| {
+                let a_seen = a.last_seen.as_deref().unwrap_or("");
+                let b_seen = b.last_seen.as_deref().unwrap_or("");
+                b_seen.cmp(a_seen)
+            });
+            rows
         },
         tool_call_stats,
     }
@@ -951,5 +959,44 @@ mod tests {
         let now = OffsetDateTime::now_utc();
         assert!(elapsed_secs_from("not-a-date", now).is_none());
         assert!(elapsed_secs_from("", now).is_none());
+    }
+
+    #[test]
+    fn test_build_snapshot_workflow_sorted_by_last_seen_desc() {
+        let mut state = State::default();
+        let agents = [
+            ("agent-a", "2026-01-01T00:00:01Z"),
+            ("agent-b", "2026-01-01T00:00:10Z"),
+            ("agent-c", "2026-01-01T00:00:05Z"),
+        ];
+        for (id, last_seen) in agents {
+            state.by_agent.insert(
+                id.to_string(),
+                AgentRow {
+                    agent_id: id.to_string(),
+                    last_seen: last_seen.to_string(),
+                    total: 1,
+                    ok: 1,
+                    warning: 0,
+                    error: 0,
+                    token_total: 0,
+                    cost_usd: 0.0,
+                    last_event: "ping".to_string(),
+                    latency_ms: None,
+                    model: String::new(),
+                    is_sidechain: false,
+                    session_id: String::new(),
+                    tool_use_counts: std::collections::HashMap::new(),
+                    display_name: String::new(),
+                },
+            );
+        }
+        let snap = build_snapshot(&state);
+        let ids: Vec<&str> = snap
+            .workflow_progress
+            .iter()
+            .map(|r| r.role_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["agent-b", "agent-c", "agent-a"]);
     }
 }


### PR DESCRIPTION
## Summary
- 활성 세션(`running`, `blocked`, `at-risk`)과 완료 세션(`completed`, `idle`)을 분리하여 렌더링
- "완료된 세션" 토글 버튼으로 완료 세션 접기/펼치기 지원, 상태를 localStorage에 저장
- 백엔드 `workflow_progress`를 `last_seen` 내림차순 정렬로 변경

## Changes
- `public/lib/workflow.js`: `splitWorkflow()` 추가 — 활성/완료 분리, lastSeen 내림차순 정렬, 완료 최대 20개 제한
- `public/lib/persistence.js`: `saveToggle()` / `loadToggle()` 추가
- `public/app.js`: `renderWorkflow()` 수정 — 분리 렌더링, 토글 버튼 연동, 활성 세션 없음 메시지
- `public/index.html`: Workflow 섹션에 토글 버튼 및 완료 영역 컨테이너 추가
- `public/styles.css`: 토글 버튼·완료 영역 접기 스타일 추가 (max-height 2000px, overflow-y auto)
- `src/state.rs`: `workflow_progress` 정렬 알파벳순 → `last_seen` 내림차순 변경

## Related Issue
Closes #95

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (91 tests)
- [x] `npm run check` pass
- [x] `node --test` pass (191 tests)
- [ ] 브라우저에서 토글 버튼 동작 확인
- [ ] 새로고침 후 토글 상태 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)