### PR TITLE
feat(api): 세션별 비용 집계 기능 추가

### DIFF
--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -5,17 +5,17 @@ import { buildCardData } from '../lib/cards.js';
 const numberFmt = new Intl.NumberFormat('ko-KR');
 
 describe('buildCardData', () => {
-  it('returns 4 cards total', () => {
-    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
+  it('returns 5 cards total', () => {
+    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5, sessions: 2 };
     const cards = buildCardData(totals, numberFmt);
-    assert.equal(cards.length, 4);
+    assert.equal(cards.length, 5);
   });
 
-  it('includes only Active, Error, Total Tokens, Cost (USD) cards', () => {
-    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05 };
+  it('includes Active, Error, Sessions, Total Tokens, Cost (USD) cards', () => {
+    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05, sessions: 3 };
     const cards = buildCardData(totals, numberFmt, 1);
     const labels = cards.map(([label]) => label);
-    assert.deepEqual(labels, ['Active', 'Error', 'Total Tokens', 'Cost (USD)']);
+    assert.deepEqual(labels, ['Active', 'Error', 'Sessions', 'Total Tokens', 'Cost (USD)']);
   });
 
   it('does not include removed cards', () => {
@@ -25,6 +25,15 @@ describe('buildCardData', () => {
     for (const removed of ['Agents', 'Total Events', 'OK', 'Warning']) {
       assert.ok(!labels.includes(removed), `${removed} card should not exist`);
     }
+  });
+
+  it('includes Sessions card with session count', () => {
+    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0, sessions: 5 };
+    const cards = buildCardData(totals, numberFmt);
+    const sessCard = cards.find(([l]) => l === 'Sessions');
+    assert.ok(sessCard, 'Sessions card should exist');
+    assert.equal(sessCard[1], '5');
+    assert.equal(sessCard[2], 'neutral');
   });
 
   it('includes Cost (USD) card with 4 decimal places', () => {

--- a/public/__tests__/state.test.js
+++ b/public/__tests__/state.test.js
@@ -29,11 +29,12 @@ describe('extractAgentMeta', () => {
 
 function makeState() {
   return {
-    totals: { total: 0, ok: 0, warning: 0, error: 0, agents: 0, tokenTotal: 0 },
+    totals: { total: 0, ok: 0, warning: 0, error: 0, agents: 0, tokenTotal: 0, sessions: 0 },
     agents: [],
     sources: [],
     recent: [],
     alerts: [],
+    sessions: [],
     workflowProgress: [],
     generatedAt: ''
   };
@@ -193,5 +194,60 @@ describe('applyIncrementalEvent', () => {
     const state = makeState();
     applyIncrementalEvent(state, makeEvent());
     assert.ok(state.generatedAt);
+  });
+
+  it('skips session when sessionId absent', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a1' }));
+    assert.equal(state.sessions.length, 0);
+  });
+
+  it('creates session entry when sessionId present', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a1', sessionId: 'sess-1' }));
+    assert.equal(state.sessions.length, 1);
+    assert.equal(state.sessions[0].sessionId, 'sess-1');
+    assert.deepEqual(state.sessions[0].agentIds, ['a1']);
+    assert.equal(state.totals.sessions, 1);
+  });
+
+  it('updates existing session entry', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a1', sessionId: 'sess-1' }));
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a2', sessionId: 'sess-1' }));
+    assert.equal(state.sessions.length, 1);
+    assert.deepEqual(state.sessions[0].agentIds, ['a1', 'a2']);
+  });
+
+  it('does not duplicate agent_id in session', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a1', sessionId: 'sess-1' }));
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a1', sessionId: 'sess-1' }));
+    assert.deepEqual(state.sessions[0].agentIds, ['a1']);
+  });
+
+  it('accumulates session tokenTotal', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({
+      agentId: 'a1', sessionId: 'sess-1',
+      metadata: { tokenUsage: { totalTokens: 300 } }
+    }));
+    assert.equal(state.sessions[0].tokenTotal, 300);
+  });
+
+  it('accumulates session costUsd on cost_update', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({
+      agentId: 'a1', sessionId: 'sess-1', event: 'cost_update',
+      metadata: { costDelta: 0.07 }
+    }));
+    assert.ok(Math.abs(state.sessions[0].costUsd - 0.07) < 1e-9);
+  });
+
+  it('updates totals.sessions count', () => {
+    const state = makeState();
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a1', sessionId: 's1' }));
+    applyIncrementalEvent(state, makeEvent({ agentId: 'a2', sessionId: 's2' }));
+    assert.equal(state.totals.sessions, 2);
   });
 });

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -2,6 +2,7 @@ export function buildCardData(totals, numberFmt, activeAgents = 0) {
   return [
     ['Active', numberFmt.format(activeAgents), activeAgents > 0 ? 'ok' : 'neutral'],
     ['Error', numberFmt.format(totals.error || 0), (totals.error || 0) > 0 ? 'error' : 'neutral'],
+    ['Sessions', numberFmt.format(totals.sessions || 0), 'neutral'],
     ['Total Tokens', numberFmt.format(totals.tokenTotal || 0), 'neutral'],
     ['Cost (USD)', Number(totals.costTotalUsd || 0).toFixed(4), 'neutral']
   ];

--- a/public/lib/state.js
+++ b/public/lib/state.js
@@ -88,6 +88,33 @@ export function applyIncrementalEvent(state, evt) {
     state.alerts = state.alerts.slice(0, 20);
   }
 
+  const sessionId = evt.sessionId || evt.metadata?.sessionId || '';
+  if (sessionId) {
+    if (!state.sessions) state.sessions = [];
+    const costDelta = evt.event === 'cost_update'
+      ? (evt.metadata?.costDelta > 0 ? evt.metadata.costDelta : 0)
+      : 0;
+    const session = state.sessions.find((s) => s.sessionId === sessionId);
+    if (!session) {
+      state.sessions.push({
+        sessionId,
+        lastSeen: evt.receivedAt,
+        tokenTotal: evtTokenTotal,
+        costUsd: costDelta,
+        agentIds: [evt.agentId]
+      });
+    } else {
+      session.lastSeen = evt.receivedAt;
+      session.tokenTotal = (session.tokenTotal || 0) + evtTokenTotal;
+      session.costUsd = (session.costUsd || 0) + costDelta;
+      if (!session.agentIds.includes(evt.agentId)) {
+        session.agentIds.push(evt.agentId);
+      }
+    }
+    state.sessions.sort((a, b) => b.lastSeen.localeCompare(a.lastSeen));
+    totals.sessions = state.sessions.length;
+  }
+
   state.workflowProgress = recalcWorkflow(state.agents);
   state.generatedAt = new Date().toISOString();
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,8 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::types::{
-    AgentRow, AlertRow, App, Event, Snapshot, SourceRow, State, ToolCallStat, WorkflowRow,
+    AgentRow, AlertRow, App, Event, SessionRow, Snapshot, SourceRow, State, ToolCallStat,
+    WorkflowRow,
 };
 use crate::utils::now_iso;
 
@@ -65,7 +66,7 @@ pub fn build_snapshot(state: &State) -> Snapshot {
     sources.sort_by(|a, b| a.source.cmp(&b.source));
 
     let totals = agents.iter().fold(
-        json!({ "agents": agents.len(), "total": 0, "ok": 0, "warning": 0, "error": 0, "tokenTotal": 0, "costTotalUsd": state.cost_total_usd }),
+        json!({ "agents": agents.len(), "total": 0, "ok": 0, "warning": 0, "error": 0, "tokenTotal": 0, "costTotalUsd": state.cost_total_usd, "sessions": state.by_session.len() }),
         |mut acc, row| {
             acc["total"] = json!(acc["total"].as_u64().unwrap_or(0) + row.total);
             acc["ok"] = json!(acc["ok"].as_u64().unwrap_or(0) + row.ok);
@@ -108,6 +109,12 @@ pub fn build_snapshot(state: &State) -> Snapshot {
             rows
         },
         tool_call_stats,
+        sessions: {
+            let mut sessions: Vec<SessionRow> = state.by_session.values().cloned().collect();
+            sessions.sort_by(|a, b| b.last_seen.cmp(&a.last_seen));
+            sessions.truncate(50);
+            sessions
+        },
     }
 }
 
@@ -209,6 +216,41 @@ pub fn append_event(app: &App, evt: Event) {
                 .tool_use_counts
                 .entry(evt.message.clone())
                 .or_insert(0) += 1;
+        }
+
+        if !evt.session_id.is_empty() {
+            let session = state
+                .by_session
+                .entry(evt.session_id.clone())
+                .or_insert(SessionRow {
+                    session_id: evt.session_id.clone(),
+                    last_seen: evt.received_at.clone(),
+                    token_total: 0,
+                    cost_usd: 0.0,
+                    agent_ids: vec![],
+                });
+            session.last_seen = evt.received_at.clone();
+            if token_total > 0 {
+                session.token_total += token_total;
+            }
+            if cost_delta > 0.0 {
+                session.cost_usd += cost_delta;
+            }
+            if !session.agent_ids.contains(&evt.agent_id) {
+                session.agent_ids.push(evt.agent_id.clone());
+            }
+
+            if state.by_session.len() > 200 {
+                if let Some(oldest_key) = state
+                    .by_session
+                    .iter()
+                    .filter(|(k, _)| k.as_str() != evt.session_id.as_str())
+                    .min_by(|a, b| a.1.last_seen.cmp(&b.1.last_seen))
+                    .map(|(k, _)| k.clone())
+                {
+                    state.by_session.remove(&oldest_key);
+                }
+            }
         }
 
         let source = evt
@@ -959,6 +1001,194 @@ mod tests {
         let now = OffsetDateTime::now_utc();
         assert!(elapsed_secs_from("not-a-date", now).is_none());
         assert!(elapsed_secs_from("", now).is_none());
+    }
+
+    // ── Session aggregation tests ──
+
+    fn make_test_event_with_session(
+        status: &str,
+        event: &str,
+        agent_id: &str,
+        session_id: &str,
+        metadata: serde_json::Value,
+    ) -> Event {
+        Event {
+            id: "e0".to_string(),
+            agent_id: agent_id.to_string(),
+            event: event.to_string(),
+            status: status.to_string(),
+            latency_ms: None,
+            message: "test".to_string(),
+            metadata,
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            received_at: "2025-01-01T00:00:00Z".to_string(),
+            model: String::new(),
+            is_sidechain: false,
+            session_id: session_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_append_event_skips_session_when_session_id_empty() {
+        let app = make_test_app();
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "msg", "a1", "", json!({})),
+        );
+        let state = app.state.lock().unwrap();
+        assert!(state.by_session.is_empty());
+    }
+
+    #[test]
+    fn test_append_event_creates_session_row() {
+        let app = make_test_app();
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "msg", "a1", "sess-1", json!({})),
+        );
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.by_session.len(), 1);
+        let sess = &state.by_session["sess-1"];
+        assert_eq!(sess.session_id, "sess-1");
+        assert!(sess.agent_ids.contains(&"a1".to_string()));
+    }
+
+    #[test]
+    fn test_append_event_session_accumulates_tokens_and_cost() {
+        let app = make_test_app();
+        let meta_tok = json!({ "tokenUsage": { "totalTokens": 200 } });
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "msg", "a1", "sess-1", meta_tok),
+        );
+        let meta_cost = json!({ "costDelta": 0.03 });
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "cost_update", "a1", "sess-1", meta_cost),
+        );
+        let state = app.state.lock().unwrap();
+        let sess = &state.by_session["sess-1"];
+        assert_eq!(sess.token_total, 200);
+        assert!((sess.cost_usd - 0.03).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_append_event_session_tracks_multiple_agent_ids() {
+        let app = make_test_app();
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "msg", "a1", "sess-1", json!({})),
+        );
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "msg", "a2", "sess-1", json!({})),
+        );
+        // duplicate agent should not add again
+        append_event(
+            &app,
+            make_test_event_with_session("ok", "msg", "a1", "sess-1", json!({})),
+        );
+        let state = app.state.lock().unwrap();
+        let sess = &state.by_session["sess-1"];
+        assert_eq!(sess.agent_ids.len(), 2);
+        assert!(sess.agent_ids.contains(&"a1".to_string()));
+        assert!(sess.agent_ids.contains(&"a2".to_string()));
+    }
+
+    #[test]
+    fn test_append_event_session_evicts_oldest_when_over_200() {
+        let app = make_test_app();
+        for i in 0..201 {
+            let mut evt =
+                make_test_event_with_session("ok", "msg", "a1", &format!("sess-{}", i), json!({}));
+            evt.received_at = format!("2025-01-01T00:00:{:02}Z", i.min(59));
+            append_event(&app, evt);
+        }
+        let state = app.state.lock().unwrap();
+        assert!(state.by_session.len() <= 200);
+    }
+
+    #[test]
+    fn test_build_snapshot_includes_sessions() {
+        let mut state = State::default();
+        state.by_session.insert(
+            "sess-1".to_string(),
+            crate::types::SessionRow {
+                session_id: "sess-1".to_string(),
+                last_seen: "2025-01-01T00:00:10Z".to_string(),
+                token_total: 100,
+                cost_usd: 0.05,
+                agent_ids: vec!["a1".to_string()],
+            },
+        );
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.sessions.len(), 1);
+        assert_eq!(snap.sessions[0].session_id, "sess-1");
+    }
+
+    #[test]
+    fn test_build_snapshot_sessions_sorted_by_last_seen_desc() {
+        let mut state = State::default();
+        let sessions = [
+            ("s1", "2025-01-01T00:00:01Z"),
+            ("s2", "2025-01-01T00:00:10Z"),
+            ("s3", "2025-01-01T00:00:05Z"),
+        ];
+        for (id, last_seen) in sessions {
+            state.by_session.insert(
+                id.to_string(),
+                crate::types::SessionRow {
+                    session_id: id.to_string(),
+                    last_seen: last_seen.to_string(),
+                    token_total: 0,
+                    cost_usd: 0.0,
+                    agent_ids: vec![],
+                },
+            );
+        }
+        let snap = build_snapshot(&state);
+        let ids: Vec<&str> = snap
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["s2", "s3", "s1"]);
+    }
+
+    #[test]
+    fn test_build_snapshot_sessions_limited_to_50() {
+        let mut state = State::default();
+        for i in 0..80 {
+            state.by_session.insert(
+                format!("s-{}", i),
+                crate::types::SessionRow {
+                    session_id: format!("s-{}", i),
+                    last_seen: format!("2025-01-01T00:{:02}:00Z", i.min(59)),
+                    token_total: 0,
+                    cost_usd: 0.0,
+                    agent_ids: vec![],
+                },
+            );
+        }
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.sessions.len(), 50);
+    }
+
+    #[test]
+    fn test_build_snapshot_totals_includes_session_count() {
+        let mut state = State::default();
+        state.by_session.insert(
+            "sess-1".to_string(),
+            crate::types::SessionRow {
+                session_id: "sess-1".to_string(),
+                last_seen: "2025-01-01T00:00:00Z".to_string(),
+                token_total: 0,
+                cost_usd: 0.0,
+                agent_ids: vec![],
+            },
+        );
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.totals["sessions"], 1);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -85,12 +85,23 @@ pub struct WorkflowRow {
     pub display_name: String,
 }
 
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRow {
+    pub session_id: String,
+    pub last_seen: String,
+    pub token_total: u64,
+    pub cost_usd: f64,
+    pub agent_ids: Vec<String>,
+}
+
 #[derive(Default)]
 pub struct State {
     pub recent: Vec<Event>,
     pub alerts: Vec<AlertRow>,
     pub by_agent: HashMap<String, AgentRow>,
     pub by_source: HashMap<String, SourceRow>,
+    pub by_session: HashMap<String, SessionRow>,
     pub token_total: u64,
     pub cost_total_usd: f64,
     pub tool_use_counts: HashMap<String, u64>,
@@ -114,6 +125,7 @@ pub struct Snapshot {
     pub alerts: Vec<AlertRow>,
     pub workflow_progress: Vec<WorkflowRow>,
     pub tool_call_stats: Vec<ToolCallStat>,
+    pub sessions: Vec<SessionRow>,
 }
 
 pub struct ParsedRequest {


### PR DESCRIPTION
## Summary
- `SessionRow` 구조체를 추가하여 세션 단위 토큰·비용을 집계하는 기반 마련
- 백엔드 `append_event()`와 `build_snapshot()`에 세션 집계 로직 추가 (최대 200개 보관, 스냅샷에 50개 포함)
- 프론트엔드 Summary Cards에 세션 수 카드 추가 및 SSE 증분 업데이트 지원

## Changes
- `src/types.rs`: `SessionRow` 구조체, `State.by_session`, `Snapshot.sessions` 필드 추가
- `src/state.rs`: `append_event()`에 세션 집계 (빈 session_id 제외, 200개 eviction), `build_snapshot()`에 sessions 포함 (last_seen 역순, 50개 제한), totals에 sessions 카운트 추가
- `public/lib/state.js`: `applyIncrementalEvent()`에 세션 업데이트 로직 및 last_seen 역순 정렬 추가
- `public/lib/cards.js`: "Sessions" 카드 추가 (5번째 카드)
- Rust 테스트 9개, JS 테스트 10개 신규 추가 (TDD)

## Related Issue
Closes #100

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (100개 테스트)
- [x] `npm run check` pass
- [x] `cargo tarpaulin --fail-under 80` pass (83.12%)
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)