### PR TITLE
feat(api): 토큰 소진율 및 플랜 쿼터 추적 기능 추가

### DIFF
--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -5,135 +5,160 @@ import { buildCardData } from '../lib/cards.js';
 const numberFmt = new Intl.NumberFormat('ko-KR');
 
 describe('buildCardData', () => {
-  it('returns 5 cards total', () => {
+  it('returns 5 base cards when no plan limit', () => {
     const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5, sessions: 2 };
     const cards = buildCardData(totals, numberFmt);
     assert.equal(cards.length, 5);
   });
 
-  it('includes Active, Error, Sessions, Total Tokens, Cost (USD) cards', () => {
+  it('includes Active, Error, Sessions, Burn Rate, Cost (USD) cards', () => {
     const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05, sessions: 3 };
     const cards = buildCardData(totals, numberFmt, 1);
-    const labels = cards.map(([label]) => label);
-    assert.deepEqual(labels, ['Active', 'Error', 'Sessions', 'Total Tokens', 'Cost (USD)']);
-  });
-
-  it('does not include removed cards', () => {
-    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05 };
-    const cards = buildCardData(totals, numberFmt);
-    const labels = cards.map(([label]) => label);
-    for (const removed of ['Agents', 'Total Events', 'OK', 'Warning']) {
-      assert.ok(!labels.includes(removed), `${removed} card should not exist`);
-    }
+    const labels = cards.map((c) => c.label);
+    assert.deepEqual(labels, ['Active', 'Error', 'Sessions', 'Burn Rate', 'Cost (USD)']);
   });
 
   it('includes Sessions card with session count', () => {
     const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0, sessions: 5 };
     const cards = buildCardData(totals, numberFmt);
-    const sessCard = cards.find(([l]) => l === 'Sessions');
+    const sessCard = cards.find((c) => c.label === 'Sessions');
     assert.ok(sessCard, 'Sessions card should exist');
-    assert.equal(sessCard[1], '5');
-    assert.equal(sessCard[2], 'neutral');
+    assert.equal(sessCard.value, '5');
+    assert.equal(sessCard.type, 'neutral');
   });
 
   it('includes Cost (USD) card with 4 decimal places', () => {
-    const totals = {
-      agents: 2,
-      total: 10,
-      tokenTotal: 500,
-      ok: 7,
-      warning: 2,
-      error: 1,
-      costTotalUsd: 0.0523
-    };
+    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.0523 };
     const cards = buildCardData(totals, numberFmt);
-    const costCard = cards.find(([label]) => label === 'Cost (USD)');
-    assert.ok(costCard, 'Cost (USD) card should exist');
-    assert.equal(costCard[1], '0.0523');
+    const costCard = cards.find((c) => c.label === 'Cost (USD)');
+    assert.ok(costCard);
+    assert.equal(costCard.value, '0.0523');
   });
 
   it('shows 0.0000 when costTotalUsd is missing', () => {
     const totals = { agents: 1, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0 };
     const cards = buildCardData(totals, numberFmt);
-    const costCard = cards.find(([label]) => label === 'Cost (USD)');
-    assert.ok(costCard, 'Cost (USD) card should exist');
-    assert.equal(costCard[1], '0.0000');
+    const costCard = cards.find((c) => c.label === 'Cost (USD)');
+    assert.equal(costCard.value, '0.0000');
   });
 
   it('shows 0.0000 when costTotalUsd is null', () => {
     const totals = { agents: 0, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: null };
     const cards = buildCardData(totals, numberFmt);
-    const costCard = cards.find(([label]) => label === 'Cost (USD)');
-    assert.equal(costCard[1], '0.0000');
-  });
-
-  it('formats token values with numberFmt', () => {
-    const totals = { agents: 1, total: 5000, tokenTotal: 50000, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const tokenCard = cards.find(([l]) => l === 'Total Tokens');
-    assert.equal(tokenCard[1], '50,000');
-  });
-
-  it('shows 0 for undefined numeric fields', () => {
-    const totals = {};
-    const cards = buildCardData(totals, numberFmt);
-    const activeCard = cards.find(([l]) => l === 'Active');
-    const errorCard = cards.find(([l]) => l === 'Error');
-    const tokenCard = cards.find(([l]) => l === 'Total Tokens');
-    const costCard = cards.find(([l]) => l === 'Cost (USD)');
-    assert.equal(activeCard[1], '0');
-    assert.equal(errorCard[1], '0');
-    assert.equal(tokenCard[1], '0');
-    assert.equal(costCard[1], '0.0000');
+    const costCard = cards.find((c) => c.label === 'Cost (USD)');
+    assert.equal(costCard.value, '0.0000');
   });
 
   it('assigns error type to Error card when error > 0', () => {
     const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 1, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt);
-    const errorCard = cards.find(([label]) => label === 'Error');
-    assert.equal(errorCard[2], 'error');
+    const errorCard = cards.find((c) => c.label === 'Error');
+    assert.equal(errorCard.type, 'error');
   });
 
   it('assigns neutral type to Error card when error is 0', () => {
     const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt);
-    const errorCard = cards.find(([label]) => label === 'Error');
-    assert.equal(errorCard[2], 'neutral');
-  });
-
-  it('assigns neutral type to Total Tokens and Cost cards', () => {
-    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
-    const cards = buildCardData(totals, numberFmt);
-    for (const label of ['Total Tokens', 'Cost (USD)']) {
-      const card = cards.find(([l]) => l === label);
-      assert.equal(card[2], 'neutral', `${label} should have neutral type`);
-    }
+    const errorCard = cards.find((c) => c.label === 'Error');
+    assert.equal(errorCard.type, 'neutral');
   });
 
   it('includes Active card with ok type when activeAgents > 0', () => {
     const totals = { agents: 2, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt, 2);
-    const activeCard = cards.find(([label]) => label === 'Active');
-    assert.ok(activeCard, 'Active card should exist');
-    assert.equal(activeCard[1], '2');
-    assert.equal(activeCard[2], 'ok');
+    const activeCard = cards.find((c) => c.label === 'Active');
+    assert.ok(activeCard);
+    assert.equal(activeCard.value, '2');
+    assert.equal(activeCard.type, 'ok');
   });
 
   it('includes Active card with neutral type when activeAgents is 0', () => {
     const totals = { agents: 2, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0 };
     const cards = buildCardData(totals, numberFmt, 0);
-    const activeCard = cards.find(([label]) => label === 'Active');
-    assert.ok(activeCard, 'Active card should exist');
-    assert.equal(activeCard[1], '0');
-    assert.equal(activeCard[2], 'neutral');
+    const activeCard = cards.find((c) => c.label === 'Active');
+    assert.equal(activeCard.value, '0');
+    assert.equal(activeCard.type, 'neutral');
   });
 
   it('defaults activeAgents to 0 when not provided', () => {
     const totals = { agents: 1, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0 };
     const cards = buildCardData(totals, numberFmt);
-    const activeCard = cards.find(([label]) => label === 'Active');
-    assert.ok(activeCard, 'Active card should exist');
-    assert.equal(activeCard[1], '0');
-    assert.equal(activeCard[2], 'neutral');
+    const activeCard = cards.find((c) => c.label === 'Active');
+    assert.equal(activeCard.value, '0');
+    assert.equal(activeCard.type, 'neutral');
+  });
+
+  it('shows burn rate as 0 tok/min when no rate', () => {
+    const totals = { tokenBurnRate: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const burnCard = cards.find((c) => c.label === 'Burn Rate');
+    assert.equal(burnCard.value, '0 tok/min');
+  });
+
+  it('formats burn rate with 1 decimal', () => {
+    const totals = { tokenBurnRate: 123.456 };
+    const cards = buildCardData(totals, numberFmt);
+    const burnCard = cards.find((c) => c.label === 'Burn Rate');
+    assert.equal(burnCard.value, '123.5 tok/min');
+  });
+
+  it('formats large burn rate in k tok/min', () => {
+    const totals = { tokenBurnRate: 2500 };
+    const cards = buildCardData(totals, numberFmt);
+    const burnCard = cards.find((c) => c.label === 'Burn Rate');
+    assert.equal(burnCard.value, '2.5k tok/min');
+  });
+
+  it('adds Plan Usage card when planLimit is set', () => {
+    const totals = { planUsagePercent: 45.0, planLimit: 100000, minutesToLimit: 120 };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.ok(usageCard);
+    assert.equal(usageCard.value, '45.0%');
+    assert.equal(usageCard.type, 'ok');
+    assert.equal(usageCard.progress, 45.0);
+    assert.equal(usageCard.sub, '120min left');
+  });
+
+  it('Plan Usage type is warning at 80%+', () => {
+    const totals = { planUsagePercent: 85, planLimit: 100000 };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.equal(usageCard.type, 'warning');
+  });
+
+  it('Plan Usage type is error at 90%+', () => {
+    const totals = { planUsagePercent: 95, planLimit: 100000 };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.equal(usageCard.type, 'error');
+  });
+
+  it('does not add Plan Usage card when planLimit is 0', () => {
+    const totals = { planUsagePercent: null, planLimit: 0 };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.equal(usageCard, undefined);
+  });
+
+  it('does not add Plan Usage card when planUsagePercent is null', () => {
+    const totals = { planUsagePercent: null, planLimit: 100000 };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.equal(usageCard, undefined);
+  });
+
+  it('Plan Usage shows empty sub when minutesToLimit is null', () => {
+    const totals = { planUsagePercent: 50, planLimit: 100000, minutesToLimit: null };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.equal(usageCard.sub, '');
+  });
+
+  it('Plan Usage shows Limit exceeded when minutesToLimit is negative', () => {
+    const totals = { planUsagePercent: 110, planLimit: 100000, minutesToLimit: -30 };
+    const cards = buildCardData(totals, numberFmt);
+    const usageCard = cards.find((c) => c.label === 'Plan Usage');
+    assert.equal(usageCard.sub, 'Limit exceeded');
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -60,10 +60,15 @@ function renderCards(totals, agents = []) {
   const activeAgents = countActiveAgents(agents);
   const cards = buildCardData(totals, numberFmt, activeAgents);
   cardsRoot.innerHTML = cards
-    .map(
-      ([label, value, type]) =>
-        `<article class="card card--${type}"><div class="label">${label}</div><div class="value">${value}</div></article>`
-    )
+    .map((c) => {
+      let html = `<article class="card card--${c.type}"><div class="label">${escapeHtml(c.label)}</div><div class="value">${escapeHtml(c.value)}</div>`;
+      if (c.progress != null) {
+        html += `<div class="progress-bar"><div class="progress-fill progress-fill--${c.type}" style="width:${Math.min(c.progress, 100)}%"></div></div>`;
+        if (c.sub) html += `<div class="card-sub">${escapeHtml(c.sub)}</div>`;
+      }
+      html += '</article>';
+      return html;
+    })
     .join('');
 }
 

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,9 +1,27 @@
 export function buildCardData(totals, numberFmt, activeAgents = 0) {
-  return [
-    ['Active', numberFmt.format(activeAgents), activeAgents > 0 ? 'ok' : 'neutral'],
-    ['Error', numberFmt.format(totals.error || 0), (totals.error || 0) > 0 ? 'error' : 'neutral'],
-    ['Sessions', numberFmt.format(totals.sessions || 0), 'neutral'],
-    ['Total Tokens', numberFmt.format(totals.tokenTotal || 0), 'neutral'],
-    ['Cost (USD)', Number(totals.costTotalUsd || 0).toFixed(4), 'neutral']
+  const cards = [
+    { label: 'Active', value: numberFmt.format(activeAgents), type: activeAgents > 0 ? 'ok' : 'neutral' },
+    { label: 'Error', value: numberFmt.format(totals.error || 0), type: (totals.error || 0) > 0 ? 'error' : 'neutral' },
+    { label: 'Sessions', value: numberFmt.format(totals.sessions || 0), type: 'neutral' },
+    { label: 'Burn Rate', value: formatBurnRate(totals.tokenBurnRate), type: 'neutral' },
+    { label: 'Cost (USD)', value: Number(totals.costTotalUsd || 0).toFixed(4), type: 'neutral' }
   ];
+
+  const usage = totals.planUsagePercent;
+  if (usage != null && totals.planLimit > 0) {
+    const type = usage >= 90 ? 'error' : usage >= 80 ? 'warning' : 'ok';
+    const minutesToLimit = totals.minutesToLimit;
+    const sub = minutesToLimit != null
+      ? (minutesToLimit < 0 ? 'Limit exceeded' : `${Math.round(minutesToLimit)}min left`)
+      : '';
+    cards.push({ label: 'Plan Usage', value: `${usage.toFixed(1)}%`, type, progress: usage, sub });
+  }
+
+  return cards;
+}
+
+function formatBurnRate(rate) {
+  if (!rate || rate <= 0) return '0 tok/min';
+  if (rate >= 1000) return `${(rate / 1000).toFixed(1)}k tok/min`;
+  return `${rate.toFixed(1)} tok/min`;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -155,6 +155,30 @@ main {
   font-weight: 600;
 }
 
+.progress-bar {
+  margin-top: 8px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--border-subtle);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.progress-fill--ok { background: var(--color-ok); }
+.progress-fill--warning { background: var(--color-warning); }
+.progress-fill--error { background: var(--color-error); }
+
+.card-sub {
+  margin-top: 4px;
+  font-size: 11px;
+  opacity: 0.65;
+}
+
 .panel {
   margin-bottom: 14px;
   padding: 12px;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,10 @@ fn main() {
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(25);
+    let plan_limit = std::env::var("CLAUDE_PLAN_LIMIT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
 
     let claude_home = std::env::var("CLAUDE_HOME")
         .map(PathBuf::from)
@@ -36,7 +40,10 @@ fn main() {
     let listener = std::net::TcpListener::bind(format!("{}:{}", host, port)).expect("bind failed");
 
     let app = App {
-        state: Arc::new(Mutex::new(State::default())),
+        state: Arc::new(Mutex::new(State {
+            plan_limit,
+            ..State::default()
+        })),
         sse_clients: Arc::new(Mutex::new(Vec::new())),
         event_seq: Arc::new(AtomicU64::new(1)),
         public_dir: Arc::new(

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,14 +4,36 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::types::{
-    AgentRow, AlertRow, App, Event, SessionRow, Snapshot, SourceRow, State, ToolCallStat,
-    WorkflowRow,
+    AgentRow, AlertRow, App, Event, SessionRow, Snapshot, SourceRow, State, TokenSample,
+    ToolCallStat, WorkflowRow,
 };
 use crate::utils::now_iso;
 
 fn elapsed_secs_from(last_seen: &str, now: OffsetDateTime) -> Option<i64> {
     let parsed = OffsetDateTime::parse(last_seen, &Rfc3339).ok()?;
     Some((now - parsed).whole_seconds())
+}
+
+pub fn calc_token_burn_rate(samples: &[TokenSample]) -> f64 {
+    if samples.len() < 2 {
+        return 0.0;
+    }
+    let first = &samples[0];
+    let last = &samples[samples.len() - 1];
+    let elapsed_secs = (last.sampled_at_dt - first.sampled_at_dt).whole_seconds();
+    if elapsed_secs <= 0 {
+        return 0.0;
+    }
+    let token_diff = last.tokens as f64 - first.tokens as f64;
+    token_diff / (elapsed_secs as f64 / 60.0)
+}
+
+pub fn calc_time_to_limit(token_total: u64, plan_limit: u64, burn_rate: f64) -> Option<f64> {
+    if plan_limit == 0 || burn_rate <= 0.0 {
+        return None;
+    }
+    let remaining = plan_limit as f64 - token_total as f64;
+    Some(remaining / burn_rate)
 }
 
 pub fn workflow_row(state: &State, role_id: &str) -> WorkflowRow {
@@ -65,8 +87,30 @@ pub fn build_snapshot(state: &State) -> Snapshot {
     let mut sources: Vec<SourceRow> = state.by_source.values().cloned().collect();
     sources.sort_by(|a, b| a.source.cmp(&b.source));
 
+    let burn_rate = calc_token_burn_rate(&state.token_samples);
+    let plan_usage_percent = if state.plan_limit > 0 {
+        json!(state.token_total as f64 / state.plan_limit as f64 * 100.0)
+    } else {
+        json!(null)
+    };
+    let minutes_to_limit = match calc_time_to_limit(state.token_total, state.plan_limit, burn_rate)
+    {
+        Some(m) => json!(m),
+        None => json!(null),
+    };
+
     let totals = agents.iter().fold(
-        json!({ "agents": agents.len(), "total": 0, "ok": 0, "warning": 0, "error": 0, "tokenTotal": 0, "costTotalUsd": state.cost_total_usd, "sessions": state.by_session.len() }),
+        json!({
+            "agents": agents.len(),
+            "total": 0, "ok": 0, "warning": 0, "error": 0,
+            "tokenTotal": 0,
+            "costTotalUsd": state.cost_total_usd,
+            "sessions": state.by_session.len(),
+            "tokenBurnRate": burn_rate,
+            "planLimit": state.plan_limit,
+            "planUsagePercent": plan_usage_percent,
+            "minutesToLimit": minutes_to_limit,
+        }),
         |mut acc, row| {
             acc["total"] = json!(acc["total"].as_u64().unwrap_or(0) + row.total);
             acc["ok"] = json!(acc["ok"].as_u64().unwrap_or(0) + row.ok);
@@ -207,6 +251,17 @@ pub fn append_event(app: &App, evt: Event) {
         // row is no longer used — update state-level accumulators
         if token_total > 0 {
             state.token_total += token_total;
+
+            // Record token sample and prune old ones (>10 min)
+            if let Ok(now_time) = OffsetDateTime::parse(&evt.received_at, &Rfc3339) {
+                let cutoff = now_time - time::Duration::minutes(10);
+                state.token_samples.retain(|s| s.sampled_at_dt >= cutoff);
+                let cumulative = state.token_total;
+                state.token_samples.push(TokenSample {
+                    tokens: cumulative,
+                    sampled_at_dt: now_time,
+                });
+            }
         }
         if cost_delta > 0.0 {
             state.cost_total_usd += cost_delta;
@@ -361,6 +416,13 @@ mod tests {
 
     fn parse_time(s: &str) -> OffsetDateTime {
         OffsetDateTime::parse(s, &Rfc3339).unwrap()
+    }
+
+    fn make_token_sample(tokens: u64, at: &str) -> TokenSample {
+        TokenSample {
+            tokens,
+            sampled_at_dt: parse_time(at),
+        }
     }
 
     #[test]
@@ -1189,6 +1251,151 @@ mod tests {
         );
         let snap = build_snapshot(&state);
         assert_eq!(snap.totals["sessions"], 1);
+    }
+
+    #[test]
+    fn test_build_snapshot_includes_burn_rate_fields() {
+        let mut state = State::default();
+        state.token_total = 5000;
+        state.plan_limit = 100_000;
+        state.token_samples = vec![
+            make_token_sample(3000, "2025-01-01T00:00:00Z"),
+            make_token_sample(5000, "2025-01-01T00:05:00Z"),
+        ];
+        let snap = build_snapshot(&state);
+        // burn rate = (5000 - 3000) / 5 = 400 tok/min
+        assert!((snap.totals["tokenBurnRate"].as_f64().unwrap() - 400.0).abs() < 0.01);
+        assert_eq!(snap.totals["planLimit"], 100_000);
+        // usage percent = 5000 / 100000 * 100 = 5.0
+        assert!((snap.totals["planUsagePercent"].as_f64().unwrap() - 5.0).abs() < 0.01);
+        // minutes to limit = (100000 - 5000) / 400 = 237.5
+        assert!((snap.totals["minutesToLimit"].as_f64().unwrap() - 237.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_build_snapshot_no_plan_limit_fields_null() {
+        let mut state = State::default();
+        state.token_total = 5000;
+        state.plan_limit = 0;
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.totals["tokenBurnRate"], 0.0);
+        assert_eq!(snap.totals["planLimit"], 0);
+        assert!(snap.totals["planUsagePercent"].is_null());
+        assert!(snap.totals["minutesToLimit"].is_null());
+    }
+
+    #[test]
+    fn test_append_event_records_token_sample() {
+        let app = make_test_app();
+        let meta = json!({ "tokenUsage": { "totalTokens": 500 } });
+        let mut evt = make_test_event("ok", "msg", "a1", meta);
+        evt.received_at = "2025-01-01T00:00:00Z".to_string();
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.token_samples.len(), 1);
+        assert_eq!(state.token_samples[0].tokens, 500);
+        assert_eq!(
+            state.token_samples[0].sampled_at_dt,
+            parse_time("2025-01-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn test_append_event_no_sample_when_zero_tokens() {
+        let app = make_test_app();
+        let evt = make_test_event("ok", "msg", "a1", json!({}));
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert!(state.token_samples.is_empty());
+    }
+
+    #[test]
+    fn test_append_event_prunes_old_samples() {
+        let app = make_test_app();
+        // Old sample: 15 minutes ago
+        let meta1 = json!({ "tokenUsage": { "totalTokens": 100 } });
+        let mut evt1 = make_test_event("ok", "msg", "a1", meta1);
+        evt1.received_at = "2025-01-01T00:00:00Z".to_string();
+        append_event(&app, evt1);
+
+        // Recent sample: 5 minutes later (still within 10 min window of next event)
+        let meta2 = json!({ "tokenUsage": { "totalTokens": 200 } });
+        let mut evt2 = make_test_event("ok", "msg", "a1", meta2);
+        evt2.received_at = "2025-01-01T00:05:00Z".to_string();
+        append_event(&app, evt2);
+
+        // New sample: 11 minutes after first → first should be pruned
+        let meta3 = json!({ "tokenUsage": { "totalTokens": 300 } });
+        let mut evt3 = make_test_event("ok", "msg", "a1", meta3);
+        evt3.received_at = "2025-01-01T00:11:00Z".to_string();
+        append_event(&app, evt3);
+
+        let state = app.state.lock().unwrap();
+        // First sample (00:00) should be pruned (>10 min before 00:11)
+        // Cumulative totals: evt1=100, evt2=100+200=300, evt3=100+200+300=600
+        assert_eq!(state.token_samples.len(), 2);
+        assert_eq!(state.token_samples[0].tokens, 300);
+        assert_eq!(state.token_samples[1].tokens, 600);
+    }
+
+    #[test]
+    fn test_calc_token_burn_rate_empty_samples() {
+        let samples: Vec<TokenSample> = vec![];
+        assert_eq!(calc_token_burn_rate(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_calc_token_burn_rate_single_sample() {
+        let samples = vec![make_token_sample(1000, "2025-01-01T00:00:00Z")];
+        assert_eq!(calc_token_burn_rate(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_calc_token_burn_rate_two_samples() {
+        let samples = vec![
+            make_token_sample(1000, "2025-01-01T00:00:00Z"),
+            make_token_sample(2000, "2025-01-01T00:05:00Z"),
+        ];
+        // (2000 - 1000) / 5 minutes = 200.0 tok/min
+        assert!((calc_token_burn_rate(&samples) - 200.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_calc_token_burn_rate_zero_elapsed() {
+        let samples = vec![
+            make_token_sample(1000, "2025-01-01T00:00:00Z"),
+            make_token_sample(2000, "2025-01-01T00:00:00Z"),
+        ];
+        assert_eq!(calc_token_burn_rate(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_calc_time_to_limit_normal() {
+        // 100 tok/min burn rate, 8000 remaining → 80 min
+        let result = calc_time_to_limit(2000, 10000, 100.0);
+        assert!((result.unwrap() - 80.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_calc_time_to_limit_no_plan() {
+        assert!(calc_time_to_limit(2000, 0, 100.0).is_none());
+    }
+
+    #[test]
+    fn test_calc_time_to_limit_zero_burn_rate() {
+        assert!(calc_time_to_limit(2000, 10000, 0.0).is_none());
+    }
+
+    #[test]
+    fn test_calc_time_to_limit_negative_burn_rate() {
+        assert!(calc_time_to_limit(2000, 10000, -5.0).is_none());
+    }
+
+    #[test]
+    fn test_calc_time_to_limit_already_exceeded() {
+        // token_total > plan_limit
+        let result = calc_time_to_limit(15000, 10000, 100.0);
+        assert!(result.unwrap() < 0.0);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,6 +95,12 @@ pub struct SessionRow {
     pub agent_ids: Vec<String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct TokenSample {
+    pub tokens: u64,
+    pub sampled_at_dt: time::OffsetDateTime,
+}
+
 #[derive(Default)]
 pub struct State {
     pub recent: Vec<Event>,
@@ -105,6 +111,8 @@ pub struct State {
     pub token_total: u64,
     pub cost_total_usd: f64,
     pub tool_use_counts: HashMap<String, u64>,
+    pub token_samples: Vec<TokenSample>,
+    pub plan_limit: u64,
 }
 
 #[derive(Clone, Serialize)]


### PR DESCRIPTION
## Summary
- 분당 토큰 소진율(burn rate) 계산 및 대시보드 표시 추가
- `CLAUDE_PLAN_LIMIT` 환경변수로 플랜 한도 설정, 사용률 및 예상 잔여 시간 표시
- 한도 초과 시 프로그레스바 색상 경고 및 "Limit exceeded" 메시지 표시

## Changes
- `src/types.rs`: `TokenSample` 구조체 추가, `State`에 `token_samples`/`plan_limit` 필드 추가
- `src/state.rs`: `calc_token_burn_rate()`, `calc_time_to_limit()` 함수 구현, `append_event()`에서 10분 슬라이딩 윈도우 샘플 기록, `build_snapshot()` totals 확장
- `src/main.rs`: `CLAUDE_PLAN_LIMIT` 환경변수 파싱
- `public/lib/cards.js`: Burn Rate 카드, Plan Usage 카드(프로그레스바) 추가, 카드 형식을 객체로 통일
- `public/app.js`: 새 카드 형식 대응 렌더링, `escapeHtml()` 적용
- `public/styles.css`: `.progress-bar`, `.progress-fill`, `.card-sub` 스타일 추가

## Related Issue
Closes #99

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (114개, 신규 14개)
- [x] `npm run check` pass
- [x] JS cards 테스트 21개 통과 (신규 9개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)