### PR TITLE
feat(ui): 에이전트 테이블 UX 개선 - model 중복 제거 및 상대 시간 표시

### DIFF
--- a/public/__tests__/agents.test.js
+++ b/public/__tests__/agents.test.js
@@ -4,115 +4,113 @@ import { resetDisplayNames } from '../lib/agent-display.js';
 import { agentRowHtml } from '../lib/renders/agents.js';
 
 describe('agentRowHtml', () => {
-  it('renders a root agent row', () => {
+  it('renders a root agent row with cost and relative time', () => {
     resetDisplayNames();
+    const now = Date.now();
     const row = {
       agentId: 'lead-abc',
       model: 'claude-3',
-      lastSeen: '2024-01-01T00:00:00Z',
-      total: 10,
-      ok: 8,
-      warning: 1,
+      lastSeen: new Date(now - 30_000).toISOString(),
       error: 1,
       tokenTotal: 5000,
+      costUsd: 0.1234,
       lastEvent: 'TaskComplete',
       latencyMs: 42
     };
-    const html = agentRowHtml(row, false, false);
+    const html = agentRowHtml(row, false, false, now);
     assert.ok(html.includes('<tr>'));
     assert.ok(html.includes('lead-abc'));
-    assert.ok(html.includes('claude-3'));
     assert.ok(html.includes('42 ms'));
+    assert.ok(html.includes('$0.1234'));
+    assert.ok(html.includes('30초 전'));
+    // model should be in tooltip, not as separate column
+    assert.ok(html.includes('claude-3'));
+    assert.ok(!html.includes('<span class="model-badge">'));
   });
 
   it('renders child agent row with tree-branch prefix', () => {
     resetDisplayNames();
+    const now = Date.now();
     const row = {
       agentId: 'sub-xyz',
       model: '',
-      lastSeen: '2024-01-01T00:00:00Z',
-      total: 3,
-      ok: 3,
-      warning: 0,
+      lastSeen: new Date(now - 3_000).toISOString(),
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'Run',
       latencyMs: null
     };
-    const html = agentRowHtml(row, true, false);
+    const html = agentRowHtml(row, true, false, now);
     assert.ok(html.includes('tree-child'));
     assert.ok(html.includes('tree-branch'));
   });
 
   it('renders last-child with tree-last class', () => {
     resetDisplayNames();
+    const now = Date.now();
     const row = {
       agentId: 'sub-xyz',
       model: '',
-      lastSeen: '2024-01-01T00:00:00Z',
-      total: 1,
-      ok: 1,
-      warning: 0,
+      lastSeen: new Date(now - 3_000).toISOString(),
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'Done',
       latencyMs: null
     };
-    const html = agentRowHtml(row, true, true);
+    const html = agentRowHtml(row, true, true, now);
     assert.ok(html.includes('tree-last'));
   });
 
-  it('shows dash when model is empty', () => {
+  it('shows model in agent title tooltip', () => {
     resetDisplayNames();
+    const now = Date.now();
     const row = {
       agentId: 'agent-1',
-      model: '',
-      lastSeen: '2024-01-01T00:00:00Z',
-      total: 1,
-      ok: 1,
-      warning: 0,
+      model: 'opus-4',
+      lastSeen: new Date(now - 3_000).toISOString(),
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'X',
       latencyMs: null
     };
-    const html = agentRowHtml(row, false, false);
-    assert.ok(html.includes('<td>-</td>'));
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('title="agent-1 | opus-4"'));
   });
 
   it('shows dash when latencyMs is null', () => {
     resetDisplayNames();
+    const now = Date.now();
     const row = {
       agentId: 'agent-2',
       model: 'opus',
-      lastSeen: '2024-01-01T00:00:00Z',
-      total: 1,
-      ok: 1,
-      warning: 0,
+      lastSeen: new Date(now - 3_000).toISOString(),
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'Y',
       latencyMs: null
     };
-    const html = agentRowHtml(row, false, false);
+    const html = agentRowHtml(row, false, false, now);
     assert.ok(html.includes('<td>-</td>'));
   });
 
   it('escapes agentId in title attribute', () => {
     resetDisplayNames();
+    const now = Date.now();
     const row = {
       agentId: '<xss>',
       model: '',
-      lastSeen: '2024-01-01T00:00:00Z',
-      total: 1,
-      ok: 1,
-      warning: 0,
+      lastSeen: new Date(now - 3_000).toISOString(),
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'Z',
       latencyMs: null
     };
-    const html = agentRowHtml(row, false, false);
+    const html = agentRowHtml(row, false, false, now);
     assert.ok(html.includes('&lt;xss&gt;'));
     assert.ok(!html.includes('<xss>'));
   });
@@ -123,12 +121,10 @@ describe('agentRowHtml', () => {
     const row = {
       agentId: 'agent-1',
       model: 'claude-3',
-      lastSeen: new Date(now - 5_000).toISOString(),
-      total: 10,
-      ok: 10,
-      warning: 0,
+      lastSeen: new Date(now - 3_000).toISOString(),
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'Run',
       latencyMs: null
     };
@@ -143,11 +139,9 @@ describe('agentRowHtml', () => {
       agentId: 'agent-2',
       model: '',
       lastSeen: new Date(now - 300_000).toISOString(),
-      total: 1,
-      ok: 1,
-      warning: 0,
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'Done',
       latencyMs: null
     };
@@ -162,15 +156,90 @@ describe('agentRowHtml', () => {
       agentId: 'agent-3',
       model: '',
       lastSeen: new Date(now - 60_000).toISOString(),
-      total: 1,
-      ok: 1,
-      warning: 0,
       error: 0,
       tokenTotal: 0,
+      costUsd: 0,
       lastEvent: 'X',
       latencyMs: null
     };
     const html = agentRowHtml(row, false, false, now);
     assert.ok(html.includes('activity-dot--recent'));
+  });
+
+  it('shows last seen absolute time in tooltip', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const lastSeen = new Date(now - 90_000).toISOString();
+    const row = {
+      agentId: 'agent-4',
+      model: '',
+      lastSeen,
+      error: 0,
+      tokenTotal: 0,
+      costUsd: 0,
+      lastEvent: 'X',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('1분 전'));
+    // tooltip should contain a title attribute (absolute time)
+    assert.match(html, /title="[^"]+"/);
+  });
+
+  it('shows empty tooltip when lastSeen is null', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const row = {
+      agentId: 'agent-null',
+      model: '',
+      lastSeen: null,
+      error: 0,
+      tokenTotal: 0,
+      costUsd: 0,
+      lastEvent: 'X',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('title=""'));
+    assert.ok(html.includes('>-<'));
+  });
+
+  it('renders cost as $0.0000 when costUsd is zero', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const row = {
+      agentId: 'agent-5',
+      model: '',
+      lastSeen: new Date(now - 3_000).toISOString(),
+      error: 0,
+      tokenTotal: 0,
+      costUsd: 0,
+      lastEvent: 'X',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    assert.ok(html.includes('$0.0000'));
+  });
+
+  it('does not render Total, OK, Warn columns', () => {
+    resetDisplayNames();
+    const now = Date.now();
+    const row = {
+      agentId: 'agent-6',
+      model: '',
+      lastSeen: new Date(now - 3_000).toISOString(),
+      total: 10,
+      ok: 8,
+      warning: 1,
+      error: 1,
+      tokenTotal: 100,
+      costUsd: 0,
+      lastEvent: 'X',
+      latencyMs: null
+    };
+    const html = agentRowHtml(row, false, false, now);
+    // should have exactly 7 <td> columns
+    const tdCount = (html.match(/<td/g) || []).length;
+    assert.equal(tdCount, 7);
   });
 });

--- a/public/__tests__/utils.test.js
+++ b/public/__tests__/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { escapeHtml, statusPill, normalizeText, getActivityStatus, activityDotHtml, countActiveAgents } from '../lib/utils.js';
+import { escapeHtml, statusPill, normalizeText, getActivityStatus, activityDotHtml, countActiveAgents, relativeTime } from '../lib/utils.js';
 
 describe('escapeHtml', () => {
   it('escapes & < > " \'', () => {
@@ -147,5 +147,54 @@ describe('countActiveAgents', () => {
     const now = Date.now();
     const agents = [{ lastSeen: new Date(now - 30_000).toISOString() }];
     assert.equal(countActiveAgents(agents, now), 0);
+  });
+});
+
+describe('relativeTime', () => {
+  it('returns "방금" for less than 5 seconds', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now - 3_000).toISOString(), now), '방금');
+  });
+
+  it('returns "N초 전" for less than 60 seconds', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now - 30_000).toISOString(), now), '30초 전');
+  });
+
+  it('returns "N분 전" for less than 60 minutes', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now - 90_000).toISOString(), now), '1분 전');
+  });
+
+  it('returns "N시간 전" for less than 24 hours', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now - 7_200_000).toISOString(), now), '2시간 전');
+  });
+
+  it('returns "N일 전" for 24 hours or more', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now - 259_200_000).toISOString(), now), '3일 전');
+  });
+
+  it('returns "-" for null', () => {
+    assert.equal(relativeTime(null), '-');
+  });
+
+  it('returns "-" for undefined', () => {
+    assert.equal(relativeTime(undefined), '-');
+  });
+
+  it('returns "방금" at exactly 0 seconds', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now).toISOString(), now), '방금');
+  });
+
+  it('returns "5초 전" at exactly 5 seconds boundary', () => {
+    const now = Date.now();
+    assert.equal(relativeTime(new Date(now - 5_000).toISOString(), now), '5초 전');
+  });
+
+  it('returns "-" for invalid date string', () => {
+    assert.equal(relativeTime('not-a-date'), '-');
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -74,8 +74,8 @@
 
       <section class="panel">
         <div class="panel-head">
-          <h2>Model 상태</h2>
-          <label for="agentFilter">Model Filter</label>
+          <h2>에이전트</h2>
+          <label for="agentFilter">필터</label>
           <select id="agentFilter">
             <option value="all">all</option>
           </select>
@@ -84,13 +84,10 @@
           <thead>
             <tr>
               <th>Agent</th>
-              <th>Model</th>
               <th>Last Seen</th>
-              <th>Total</th>
-              <th>OK</th>
-              <th>Warn</th>
               <th>Error</th>
               <th>Tokens</th>
+              <th>Cost</th>
               <th>Last Event</th>
               <th>Latency</th>
             </tr>

--- a/public/lib/renders/agents.js
+++ b/public/lib/renders/agents.js
@@ -1,4 +1,4 @@
-import { escapeHtml, getActivityStatus, activityDotHtml } from '../utils.js';
+import { escapeHtml, getActivityStatus, activityDotHtml, relativeTime } from '../utils.js';
 import { displayNameFor } from '../agent-display.js';
 import { buildAgentTree } from '../agent-tree.js';
 
@@ -8,20 +8,17 @@ export function agentRowHtml(row, isChild, isLastChild, now = Date.now()) {
   const prefix = isChild ? '<span class="tree-branch"></span>' : '';
   const classes = [isChild && 'tree-child', isLastChild && 'tree-last'].filter(Boolean).join(' ');
   const cls = classes ? ` class="${classes}"` : '';
-  const modelBadge = row.model
-    ? `<span class="model-badge">${escapeHtml(row.model)}</span>`
-    : '-';
+  const titleAttr = row.model
+    ? `${escapeHtml(row.agentId)} | ${escapeHtml(row.model)}`
+    : escapeHtml(row.agentId);
   const dot = activityDotHtml(getActivityStatus(row.lastSeen, now));
   return `
     <tr${cls}>
-      <td>${prefix}${dot}<span class="badge" title="${escapeHtml(row.agentId)}">${escapeHtml(row.displayName || displayNameFor(row.agentId, row.model))}</span></td>
-      <td>${modelBadge}</td>
-      <td>${new Date(row.lastSeen).toLocaleTimeString()}</td>
-      <td>${Number(row.total) || 0}</td>
-      <td>${Number(row.ok) || 0}</td>
-      <td>${Number(row.warning) || 0}</td>
+      <td>${prefix}${dot}<span class="badge" title="${titleAttr}">${escapeHtml(row.displayName || displayNameFor(row.agentId, row.model))}</span></td>
+      <td title="${row.lastSeen ? new Date(row.lastSeen).toLocaleTimeString() : ''}">${relativeTime(row.lastSeen, now)}</td>
       <td>${Number(row.error) || 0}</td>
       <td>${numberFmt.format(row.tokenTotal || 0)}</td>
+      <td>$${(row.costUsd || 0).toFixed(4)}</td>
       <td>${escapeHtml(row.lastEvent)}</td>
       <td>${row.latencyMs == null ? '-' : `${row.latencyMs} ms`}</td>
     </tr>`;

--- a/public/lib/utils.js
+++ b/public/lib/utils.js
@@ -33,6 +33,18 @@ export function activityDotHtml(status) {
   return `<span class="activity-dot activity-dot--${safe}" aria-label="${safe}"></span>`;
 }
 
+export function relativeTime(isoString, now = Date.now()) {
+  if (!isoString) return '-';
+  const ms = new Date(isoString).getTime();
+  if (isNaN(ms)) return '-';
+  const elapsed = Math.floor((now - ms) / 1000);
+  if (elapsed < 5) return '방금';
+  if (elapsed < 60) return `${elapsed}초 전`;
+  if (elapsed < 3600) return `${Math.floor(elapsed / 60)}분 전`;
+  if (elapsed < 86400) return `${Math.floor(elapsed / 3600)}시간 전`;
+  return `${Math.floor(elapsed / 86400)}일 전`;
+}
+
 export function countActiveAgents(agents, now = Date.now()) {
   return agents.filter((a) => now - new Date(a.lastSeen).getTime() < 30_000).length;
 }


### PR DESCRIPTION
## Summary

- 에이전트 패널 이름 "Model 상태" → "에이전트", 필터 레이블 "Model Filter" → "필터"로 변경
- 에이전트 테이블 컬럼 10개 → 7개로 축소 (Model/Total/OK/Warn 제거, Cost 추가)
- Last Seen 절대 시각 → 상대 시간 표시 ("3초 전", "2분 전" 등), tooltip에 절대 시각 유지
- model명을 Agent 컬럼 tooltip에 통합하여 중복 노출 제거

## Changes

- `public/lib/utils.js`: `relativeTime()` 함수 추가 (유효하지 않은 날짜 문자열 방어 처리 포함)
- `public/lib/renders/agents.js`: 컬럼 재구성, 상대 시간 전환, null lastSeen tooltip 방어 처리
- `public/index.html`: 패널명/필터명/컬럼 헤더 변경 (10→7개)
- `public/__tests__/utils.test.js`: `relativeTime()` 테스트 10개 추가
- `public/__tests__/agents.test.js`: 새 컬럼 구조에 맞게 테스트 재작성 (12→14개)

## Related Issue

Closes #106

## Test Plan

- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)