### PR TITLE
feat(api): 인메모리 시간별 토큰/비용 버킷 집계 추가

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::thread;
 use collector::spawn_claude_collector;
 use http::{handle_client, spawn_sse_sweeper};
 use types::{App, State};
+use utils::now_iso;
 
 fn main() {
     let host = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
@@ -35,7 +36,10 @@ fn main() {
     let listener = std::net::TcpListener::bind(format!("{}:{}", host, port)).expect("bind failed");
 
     let app = App {
-        state: Arc::new(Mutex::new(State::default())),
+        state: Arc::new(Mutex::new(State {
+            started_at: now_iso(),
+            ..State::default()
+        })),
         sse_clients: Arc::new(Mutex::new(Vec::new())),
         event_seq: Arc::new(AtomicU64::new(1)),
         public_dir: Arc::new(

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,8 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::types::{
-    AgentRow, AlertRow, App, Event, SessionRow, Snapshot, SourceRow, State, ToolCallStat,
-    WorkflowRow,
+    AgentRow, AlertRow, App, Event, HourBucket, SessionRow, Snapshot, SourceRow, State,
+    ToolCallStat, WorkflowRow,
 };
 use crate::utils::now_iso;
 
@@ -112,6 +112,8 @@ pub fn build_snapshot(state: &State) -> Snapshot {
         sources,
         recent: state.recent.iter().take(300).cloned().collect(),
         alerts: state.alerts.iter().take(20).cloned().collect(),
+        started_at: state.started_at.clone(),
+        hourly_buckets: state.hourly_buckets.clone(),
         workflow_progress: {
             let mut rows: Vec<WorkflowRow> = state
                 .by_agent
@@ -264,6 +266,31 @@ pub fn append_event(app: &App, evt: Event) {
         if cost_delta > 0.0 {
             state.cost_total_usd += cost_delta;
         }
+
+        if (token_total > 0 || cost_delta > 0.0) && evt.received_at.len() >= 13 {
+            let hour_key = &evt.received_at[..13];
+            // rev() scan is O(1) in normal operation (latest bucket matches);
+            // worst-case O(744) for backfilled events, acceptable for bounded vec.
+            if let Some(bucket) = state
+                .hourly_buckets
+                .iter_mut()
+                .rev()
+                .find(|b| b.hour_key == hour_key)
+            {
+                bucket.token_total += token_total;
+                bucket.cost_usd += cost_delta;
+            } else {
+                state.hourly_buckets.push(HourBucket {
+                    hour_key: hour_key.to_string(),
+                    token_total,
+                    cost_usd: cost_delta,
+                });
+                if state.hourly_buckets.len() > 744 {
+                    state.hourly_buckets.remove(0);
+                }
+            }
+        }
+
         if evt.event == "tool_call" {
             *state
                 .tool_use_counts
@@ -1589,5 +1616,133 @@ mod tests {
             extract_project_name("/home/user/repo/.claude/worktrees/fix/bug-42/subdir"),
             "bug-42"
         );
+    }
+
+    // ── Hourly bucket tests ──
+
+    fn make_event_with_received_at(
+        event: &str,
+        received_at: &str,
+        metadata: serde_json::Value,
+    ) -> Event {
+        Event {
+            id: "e0".to_string(),
+            agent_id: "a1".to_string(),
+            event: event.to_string(),
+            status: "ok".to_string(),
+            latency_ms: None,
+            message: "test".to_string(),
+            metadata,
+            timestamp: received_at.to_string(),
+            received_at: received_at.to_string(),
+            model: String::new(),
+            is_sidechain: false,
+            session_id: String::new(),
+            cwd: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_hourly_bucket_created_on_token_event() {
+        let app = make_test_app();
+        let meta = json!({ "tokenUsage": { "totalTokens": 100 } });
+        let evt = make_event_with_received_at("msg", "2025-01-01T14:00:00Z", meta);
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.hourly_buckets.len(), 1);
+        assert_eq!(state.hourly_buckets[0].hour_key, "2025-01-01T14");
+        assert_eq!(state.hourly_buckets[0].token_total, 100);
+    }
+
+    #[test]
+    fn test_hourly_bucket_accumulates_same_hour() {
+        let app = make_test_app();
+        let meta1 = json!({ "tokenUsage": { "totalTokens": 100 } });
+        let evt1 = make_event_with_received_at("msg", "2025-01-01T14:00:00Z", meta1);
+        let meta2 = json!({ "tokenUsage": { "totalTokens": 200 } });
+        let evt2 = make_event_with_received_at("msg", "2025-01-01T14:30:00Z", meta2);
+        append_event(&app, evt1);
+        append_event(&app, evt2);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.hourly_buckets.len(), 1);
+        assert_eq!(state.hourly_buckets[0].token_total, 300);
+    }
+
+    #[test]
+    fn test_hourly_bucket_new_hour_creates_new() {
+        let app = make_test_app();
+        let meta1 = json!({ "tokenUsage": { "totalTokens": 100 } });
+        let evt1 = make_event_with_received_at("msg", "2025-01-01T14:00:00Z", meta1);
+        let meta2 = json!({ "tokenUsage": { "totalTokens": 200 } });
+        let evt2 = make_event_with_received_at("msg", "2025-01-01T15:00:00Z", meta2);
+        append_event(&app, evt1);
+        append_event(&app, evt2);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.hourly_buckets.len(), 2);
+        assert_eq!(state.hourly_buckets[0].hour_key, "2025-01-01T14");
+        assert_eq!(state.hourly_buckets[1].hour_key, "2025-01-01T15");
+    }
+
+    #[test]
+    fn test_hourly_bucket_max_744() {
+        let app = make_test_app();
+        for i in 0..745 {
+            let hour = i % 24;
+            let day = 1 + i / 24;
+            let received_at = format!(
+                "2025-{:02}-{:02}T{:02}:00:00Z",
+                (day / 28) + 1,
+                (day % 28) + 1,
+                hour
+            );
+            let meta = json!({ "tokenUsage": { "totalTokens": 1 } });
+            let evt = make_event_with_received_at("msg", &received_at, meta);
+            append_event(&app, evt);
+        }
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.hourly_buckets.len(), 744);
+    }
+
+    #[test]
+    fn test_hourly_bucket_cost_only() {
+        let app = make_test_app();
+        let meta = json!({ "costDelta": 0.05 });
+        let evt = make_event_with_received_at("cost_update", "2025-01-01T14:00:00Z", meta);
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert_eq!(state.hourly_buckets.len(), 1);
+        assert_eq!(state.hourly_buckets[0].token_total, 0);
+        assert!((state.hourly_buckets[0].cost_usd - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_hourly_bucket_no_token_no_cost_skipped() {
+        let app = make_test_app();
+        let evt = make_event_with_received_at("msg", "2025-01-01T14:00:00Z", json!({}));
+        append_event(&app, evt);
+        let state = app.state.lock().unwrap();
+        assert!(state.hourly_buckets.is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_includes_started_at() {
+        let mut state = State::default();
+        state.started_at = "2025-01-01T00:00:00Z".to_string();
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.started_at, "2025-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_snapshot_includes_hourly_buckets() {
+        let mut state = State::default();
+        state.hourly_buckets.push(HourBucket {
+            hour_key: "2025-01-01T14".to_string(),
+            token_total: 500,
+            cost_usd: 0.10,
+        });
+        let snap = build_snapshot(&state);
+        assert_eq!(snap.hourly_buckets.len(), 1);
+        assert_eq!(snap.hourly_buckets[0].hour_key, "2025-01-01T14");
+        assert_eq!(snap.hourly_buckets[0].token_total, 500);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,6 +99,14 @@ pub struct SessionRow {
     pub agent_ids: Vec<String>,
 }
 
+#[derive(Clone, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HourBucket {
+    pub hour_key: String,
+    pub token_total: u64,
+    pub cost_usd: f64,
+}
+
 #[derive(Default)]
 pub struct State {
     pub recent: Vec<Event>,
@@ -110,6 +118,8 @@ pub struct State {
     pub token_total: u64,
     pub cost_total_usd: f64,
     pub tool_use_counts: HashMap<String, u64>,
+    pub started_at: String,
+    pub hourly_buckets: Vec<HourBucket>,
 }
 
 #[derive(Clone, Serialize)]
@@ -131,6 +141,8 @@ pub struct Snapshot {
     pub workflow_progress: Vec<WorkflowRow>,
     pub tool_call_stats: Vec<ToolCallStat>,
     pub sessions: Vec<SessionRow>,
+    pub started_at: String,
+    pub hourly_buckets: Vec<HourBucket>,
 }
 
 pub struct ParsedRequest {


### PR DESCRIPTION
## Summary
- `HourBucket` 구조체 추가 (`hour_key`, `token_total`, `cost_usd`)
- `State`에 `started_at`, `hourly_buckets` 필드 추가
- `Snapshot`에 동일 필드 노출, `main.rs`에서 서버 시작 시각 초기화

## Changes
- `src/types.rs`: `HourBucket` 구조체, `State`·`Snapshot`에 신규 필드 추가
- `src/state.rs`: `append_event()`에 시간 버킷 갱신 로직 (최대 744개), `build_snapshot()`에 `started_at`·`hourly_buckets` 포함, 테스트 8개 추가
- `src/main.rs`: `started_at: now_iso()` 초기화

## Related Issue
Closes #108

## Test Plan
- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` pass (133 tests)
- [x] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)