### PR TITLE
feat: add session export endpoint

### DIFF
--- a/public/__tests__/sessions.test.js
+++ b/public/__tests__/sessions.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderSessionsList, renderSessionDetail } from '../lib/renders/sessions.js';
+import { getSessionExportAttrs, renderSessionsList, renderSessionDetail } from '../lib/renders/sessions.js';
 
 function makeRoot() {
   return { innerHTML: '', dataset: {} };
@@ -55,5 +55,18 @@ describe('renderSessionDetail', () => {
   it('renders empty message when no events', () => {
     renderSessionDetail([], root);
     assert.ok(root.innerHTML.includes('이벤트 없음'));
+  });
+});
+
+describe('getSessionExportAttrs', () => {
+  it('builds a same-origin export link and safe filename', () => {
+    const attrs = getSessionExportAttrs('sess 1/alpha');
+    assert.equal(attrs.href, '/api/sessions/sess%201%2Falpha/export');
+    assert.equal(attrs.download, 'session-sess_1_alpha.json');
+  });
+
+  it('falls back to a stable filename when session id is blank', () => {
+    const attrs = getSessionExportAttrs('   ');
+    assert.equal(attrs.download, 'session-detail.json');
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -11,7 +11,7 @@ import { getFilteredEvents, renderEventMeta, renderEvents } from './lib/renders/
 import { renderAgents, populateAgentFilter } from './lib/renders/agents.js';
 import { renderAlerts } from './lib/renders/alerts.js';
 import { renderTimeline } from './lib/renders/timeline.js';
-import { renderSessionsList, renderSessionDetail, fetchSessionEvents } from './lib/renders/sessions.js';
+import { renderSessionsList, renderSessionDetail, fetchSessionEvents, getSessionExportAttrs } from './lib/renders/sessions.js';
 
 const cardsRoot = document.getElementById('cards');
 const workflowRoot = document.getElementById('workflow');
@@ -34,6 +34,7 @@ const sessionsListRoot = document.getElementById('sessionsList');
 const sessionDetailRoot = document.getElementById('sessionDetail');
 const sessionDetailBack = document.getElementById('sessionDetailBack');
 const sessionDetailTitle = document.getElementById('sessionDetailTitle');
+const sessionDetailExport = document.getElementById('sessionDetailExport');
 const sessionDetailEvents = document.getElementById('sessionDetailEvents');
 
 const chartEls = {
@@ -161,6 +162,11 @@ function openSessionDetail(sessionId) {
   sessionsListRoot.hidden = true;
   sessionDetailRoot.hidden = false;
   sessionDetailTitle.textContent = sessionId;
+  if (sessionDetailExport) {
+    const attrs = getSessionExportAttrs(sessionId);
+    sessionDetailExport.href = attrs.href;
+    sessionDetailExport.download = attrs.download;
+  }
   sessionDetailEvents.innerHTML = '<p>로딩 중...</p>';
   fetchSessionEvents(sessionId).then((events) => {
     renderSessionDetail(events, sessionDetailEvents);

--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,10 @@
         <div id="sessionDetail" class="session-detail" hidden>
           <div class="session-detail-head">
             <button id="sessionDetailBack" class="session-back-btn">&larr; 목록으로</button>
-            <span id="sessionDetailTitle"></span>
+            <span id="sessionDetailTitle" class="session-detail-title"></span>
+            <a id="sessionDetailExport" class="session-export-btn" href="#" download title="현재 세션을 로컬 JSON으로 저장">
+              Export JSON
+            </a>
           </div>
           <div id="sessionDetailEvents" class="events"></div>
         </div>

--- a/public/lib/renders/sessions.js
+++ b/public/lib/renders/sessions.js
@@ -50,6 +50,21 @@ export function renderSessionDetail(events, root) {
     .join('');
 }
 
+function sanitizeExportSegment(value) {
+  const safe = String(value ?? '')
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return safe || 'detail';
+}
+
+export function getSessionExportAttrs(sessionId) {
+  return {
+    href: `/api/sessions/${encodeURIComponent(sessionId)}/export`,
+    download: `session-${sanitizeExportSegment(sessionId)}.json`
+  };
+}
+
 export async function fetchSessionEvents(sessionId) {
   const resp = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/events`);
   if (!resp.ok) return [];

--- a/public/styles.css
+++ b/public/styles.css
@@ -977,9 +977,18 @@ tr.tree-last .tree-branch::before {
   align-items: center;
   gap: 12px;
   margin-bottom: 8px;
+  flex-wrap: wrap;
 }
 
-.session-back-btn {
+.session-detail-title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-back-btn,
+.session-export-btn {
   background: none;
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -987,8 +996,14 @@ tr.tree-last .tree-branch::before {
   cursor: pointer;
   color: var(--warm-text);
   font-size: 13px;
+  text-decoration: none;
 }
 
-.session-back-btn:hover {
+.session-export-btn {
+  margin-left: auto;
+}
+
+.session-back-btn:hover,
+.session-export-btn:hover {
   background: var(--hover-overlay);
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 #[cfg(test)]
 use crate::state::broadcast_sse;
-use crate::state::{build_snapshot, get_session_events};
+use crate::state::{build_snapshot, get_session_events, get_session_export};
 use crate::types::{App, ParsedRequest};
 use crate::utils::{bytes_response, content_type_for, json_response, now_iso};
 
@@ -119,6 +119,10 @@ pub fn spawn_sse_sweeper(app: App) {
     });
 }
 
+fn session_route_id<'a>(path: &'a str, suffix: &str) -> Option<&'a str> {
+    path.strip_prefix("/api/sessions/")?.strip_suffix(suffix)
+}
+
 pub fn handle_client(mut stream: TcpStream, app: App) {
     let req = match parse_request(&mut stream) {
         Some(r) => r,
@@ -151,14 +155,33 @@ pub fn handle_client(mut stream: TcpStream, app: App) {
             };
             let _ = stream.write_all(&json_response("200 OK", &body));
         }
-        ("GET", path) if path.starts_with("/api/sessions/") && path.ends_with("/events") => {
-            let session_id = &path["/api/sessions/".len()..path.len() - "/events".len()];
+        ("GET", path) if session_route_id(path, "/events").is_some() => {
+            let session_id = session_route_id(path, "/events").unwrap_or_default();
             let body = {
                 let state = app.state.lock().unwrap_or_else(|e| e.into_inner());
                 let events = get_session_events(&state, session_id);
                 serde_json::to_string(&events).unwrap_or_else(|_| "[]".to_string())
             };
             let _ = stream.write_all(&json_response("200 OK", &body));
+        }
+        ("GET", path) if session_route_id(path, "/export").is_some() => {
+            let session_id = session_route_id(path, "/export").unwrap_or_default();
+            let export = {
+                let state = app.state.lock().unwrap_or_else(|e| e.into_inner());
+                get_session_export(&state, session_id)
+            };
+            match export {
+                Some(export) => {
+                    let body = serde_json::to_string(&export).unwrap_or_else(|_| "{}".to_string());
+                    let _ = stream.write_all(&json_response("200 OK", &body));
+                }
+                None => {
+                    let _ = stream.write_all(&json_response(
+                        "404 Not Found",
+                        &json!({ "error": "Session not found" }).to_string(),
+                    ));
+                }
+            }
         }
         ("GET", "/api/stream") => {
             let snapshot = {
@@ -231,6 +254,10 @@ mod tests {
         let mut buf = Vec::new();
         let _ = stream.read_to_end(&mut buf);
         String::from_utf8_lossy(&buf).to_string()
+    }
+
+    fn response_body(resp: &str) -> &str {
+        resp.split("\r\n\r\n").nth(1).unwrap_or("")
     }
 
     fn unique_tmp_dir(name: &str) -> PathBuf {
@@ -449,6 +476,91 @@ mod tests {
         handle.join().unwrap();
         assert!(resp.contains("200 OK"));
         assert!(resp.contains("[]"));
+    }
+
+    #[test]
+    fn test_handle_client_session_export_200() {
+        use crate::state::append_event;
+        use crate::types::Event;
+
+        let app = make_test_app();
+        append_event(
+            &app,
+            Event {
+                id: "e1".to_string(),
+                agent_id: "a1".to_string(),
+                event: "token_usage".to_string(),
+                status: "ok".to_string(),
+                latency_ms: None,
+                message: "tokens +200".to_string(),
+                metadata: serde_json::json!({
+                    "tokenUsage": { "totalTokens": 200 }
+                }),
+                timestamp: "2025-01-01T00:00:00Z".to_string(),
+                received_at: "2025-01-01T00:00:00Z".to_string(),
+                model: String::new(),
+                is_sidechain: false,
+                session_id: "sess-abc".to_string(),
+                cwd: String::new(),
+            },
+        );
+        append_event(
+            &app,
+            Event {
+                id: "e2".to_string(),
+                agent_id: "a2".to_string(),
+                event: "cost_update".to_string(),
+                status: "ok".to_string(),
+                latency_ms: None,
+                message: "cost +0.03".to_string(),
+                metadata: serde_json::json!({
+                    "costDelta": 0.03
+                }),
+                timestamp: "2025-01-01T00:00:01Z".to_string(),
+                received_at: "2025-01-01T00:00:01Z".to_string(),
+                model: String::new(),
+                is_sidechain: false,
+                session_id: "sess-abc".to_string(),
+                cwd: String::new(),
+            },
+        );
+
+        let (addr, handle) = spawn_test_server(app);
+        let resp = http_request(
+            &addr,
+            "GET /api/sessions/sess-abc/export HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        );
+        handle.join().unwrap();
+
+        assert!(resp.contains("200 OK"));
+
+        let body: serde_json::Value = serde_json::from_str(response_body(&resp)).unwrap();
+        assert_eq!(body["summary"]["sessionId"], "sess-abc");
+        assert_eq!(body["summary"]["tokenTotal"], 200);
+        assert_eq!(
+            body["events"].as_array().map(|events| events.len()),
+            Some(2)
+        );
+        assert_eq!(
+            body["summary"]["agentIds"].as_array().map(|ids| ids.len()),
+            Some(2)
+        );
+        assert!(body["summary"]["costUsd"].as_f64().unwrap_or_default() > 0.0);
+        assert!(body["exportedAt"].as_str().is_some());
+    }
+
+    #[test]
+    fn test_handle_client_session_export_404_for_unknown() {
+        let (addr, handle) = spawn_test_server(make_test_app());
+        let resp = http_request(
+            &addr,
+            "GET /api/sessions/nonexistent/export HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        );
+        handle.join().unwrap();
+
+        assert!(resp.contains("404 Not Found"));
+        let body: serde_json::Value = serde_json::from_str(response_body(&resp)).unwrap();
+        assert_eq!(body["error"], "Session not found");
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,8 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::types::{
-    AgentRow, AlertRow, App, Event, HourBucket, SessionRow, Snapshot, SourceRow, State,
-    ToolCallStat, WorkflowRow,
+    AgentRow, AlertRow, App, Event, HourBucket, SessionExport, SessionRow, Snapshot, SourceRow,
+    State, ToolCallStat, WorkflowRow,
 };
 use crate::utils::now_iso;
 
@@ -64,6 +64,15 @@ pub fn get_session_events(state: &State, session_id: &str) -> Vec<Event> {
         .get(session_id)
         .cloned()
         .unwrap_or_default()
+}
+
+pub fn get_session_export(state: &State, session_id: &str) -> Option<SessionExport> {
+    let summary = state.by_session.get(session_id)?.clone();
+    Some(SessionExport {
+        exported_at: now_iso(),
+        summary,
+        events: get_session_events(state, session_id),
+    })
 }
 
 pub fn build_snapshot(state: &State) -> Snapshot {

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,6 +102,14 @@ pub struct SessionRow {
     pub agent_ids: Vec<String>,
 }
 
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionExport {
+    pub exported_at: String,
+    pub summary: SessionRow,
+    pub events: Vec<Event>,
+}
+
 #[derive(Clone, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct HourBucket {


### PR DESCRIPTION
## Summary
- add a session export API that returns session summary and events as JSON
- expose a JSON export action in session detail
- cover the export behavior with Rust and JS tests

## Testing
- cargo test
- npm run check
- node --test public/__tests__/*.test.js

Closes #131