### PR TITLE
feat: session-centered summary cards

### DIFF
--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -4,162 +4,141 @@ import { buildCardData } from '../lib/cards.js';
 
 const numberFmt = new Intl.NumberFormat('ko-KR');
 
+const makeSessions = (states) => states.map((sessionState) => ({ sessionState }));
+
 describe('buildCardData', () => {
   it('returns 5 cards total', () => {
-    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5, sessions: 2 };
-    const cards = buildCardData(totals, numberFmt);
+    const cards = buildCardData([], {}, numberFmt);
     assert.equal(cards.length, 5);
   });
 
-  it('includes Active, Error, Sessions, Total Tokens, Cost (USD) cards', () => {
-    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05, sessions: 3 };
-    const cards = buildCardData(totals, numberFmt, 1);
+  it('returns correct Korean labels', () => {
+    const cards = buildCardData([], {}, numberFmt);
     const labels = cards.map((c) => c.label);
-    assert.deepEqual(labels, ['Active', 'Error', 'Sessions', 'Total Tokens', 'Cost (USD)']);
+    assert.deepEqual(labels, ['활성 세션', '주의 필요', '세션', '전체 토큰', '비용 (USD)']);
   });
 
-  it('does not include removed cards', () => {
-    const totals = { agents: 2, total: 10, tokenTotal: 500, ok: 7, warning: 2, error: 1, costTotalUsd: 0.05 };
-    const cards = buildCardData(totals, numberFmt);
+  it('does not include old agent-centric card labels', () => {
+    const cards = buildCardData([], {}, numberFmt);
     const labels = cards.map((c) => c.label);
-    for (const removed of ['Agents', 'Total Events', 'OK', 'Warning']) {
+    for (const removed of ['Active', 'Error', 'Sessions', 'Total Tokens', 'Cost (USD)', 'Agents']) {
       assert.ok(!labels.includes(removed), `${removed} card should not exist`);
     }
   });
 
-  it('includes Sessions card with session count', () => {
-    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0, sessions: 5 };
-    const cards = buildCardData(totals, numberFmt);
-    const sessCard = cards.find((c) => c.label === 'Sessions');
-    assert.ok(sessCard, 'Sessions card should exist');
-    assert.equal(sessCard.value, '5');
-    assert.equal(sessCard.type, 'neutral');
+  it('counts active sessions correctly', () => {
+    const sessions = makeSessions(['active', 'active', 'completed', 'idle']);
+    const cards = buildCardData(sessions, {}, numberFmt);
+    const card = cards.find((c) => c.label === '활성 세션');
+    assert.equal(card.value, '2');
+    assert.equal(card.type, 'ok');
   });
 
-  it('includes Cost (USD) card with 4 decimal places', () => {
-    const totals = {
-      agents: 2,
-      total: 10,
-      tokenTotal: 500,
-      ok: 7,
-      warning: 2,
-      error: 1,
-      costTotalUsd: 0.0523
-    };
-    const cards = buildCardData(totals, numberFmt);
-    const costCard = cards.find((c) => c.label === 'Cost (USD)');
-    assert.ok(costCard, 'Cost (USD) card should exist');
-    assert.equal(costCard.value, '0.0523');
+  it('assigns neutral type to 활성 세션 when count is 0', () => {
+    const sessions = makeSessions(['completed', 'idle']);
+    const cards = buildCardData(sessions, {}, numberFmt);
+    const card = cards.find((c) => c.label === '활성 세션');
+    assert.equal(card.value, '0');
+    assert.equal(card.type, 'neutral');
+  });
+
+  it('counts stuck + failed sessions as 주의 필요', () => {
+    const sessions = makeSessions(['active', 'stuck', 'failed', 'completed']);
+    const cards = buildCardData(sessions, {}, numberFmt);
+    const card = cards.find((c) => c.label === '주의 필요');
+    assert.equal(card.value, '2');
+    assert.equal(card.type, 'warning');
+  });
+
+  it('assigns neutral type to 주의 필요 when count is 0', () => {
+    const sessions = makeSessions(['active', 'completed']);
+    const cards = buildCardData(sessions, {}, numberFmt);
+    const card = cards.find((c) => c.label === '주의 필요');
+    assert.equal(card.value, '0');
+    assert.equal(card.type, 'neutral');
+  });
+
+  it('shows total session count in 세션 card', () => {
+    const sessions = makeSessions(['active', 'stuck', 'completed', 'idle', 'failed']);
+    const cards = buildCardData(sessions, {}, numberFmt);
+    const card = cards.find((c) => c.label === '세션');
+    assert.equal(card.value, '5');
+    assert.equal(card.type, 'neutral');
+  });
+
+  it('shows 0 for all counts when sessions is empty', () => {
+    const cards = buildCardData([], {}, numberFmt);
+    assert.equal(cards.find((c) => c.label === '활성 세션').value, '0');
+    assert.equal(cards.find((c) => c.label === '주의 필요').value, '0');
+    assert.equal(cards.find((c) => c.label === '세션').value, '0');
+  });
+
+  it('shows 전체 토큰 with totals when no rangeInfo', () => {
+    const totals = { tokenTotal: 50000, costTotalUsd: 0 };
+    const cards = buildCardData([], totals, numberFmt);
+    const card = cards.find((c) => c.label === '전체 토큰');
+    assert.ok(card, '전체 토큰 card should exist');
+    assert.equal(card.value, '50,000');
+    assert.equal(card.type, 'neutral');
+  });
+
+  it('shows 비용 (USD) with 4 decimal places when no rangeInfo', () => {
+    const totals = { tokenTotal: 0, costTotalUsd: 0.0523 };
+    const cards = buildCardData([], totals, numberFmt);
+    const card = cards.find((c) => c.label === '비용 (USD)');
+    assert.ok(card, '비용 (USD) card should exist');
+    assert.equal(card.value, '0.0523');
+    assert.equal(card.type, 'neutral');
   });
 
   it('shows 0.0000 when costTotalUsd is missing', () => {
-    const totals = { agents: 1, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const costCard = cards.find((c) => c.label === 'Cost (USD)');
-    assert.ok(costCard, 'Cost (USD) card should exist');
-    assert.equal(costCard.value, '0.0000');
+    const cards = buildCardData([], {}, numberFmt);
+    const card = cards.find((c) => c.label === '비용 (USD)');
+    assert.equal(card.value, '0.0000');
   });
 
   it('shows 0.0000 when costTotalUsd is null', () => {
-    const totals = { agents: 0, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: null };
-    const cards = buildCardData(totals, numberFmt);
-    const costCard = cards.find((c) => c.label === 'Cost (USD)');
-    assert.equal(costCard.value, '0.0000');
+    const cards = buildCardData([], { costTotalUsd: null }, numberFmt);
+    const card = cards.find((c) => c.label === '비용 (USD)');
+    assert.equal(card.value, '0.0000');
   });
 
-  it('formats token values with numberFmt', () => {
-    const totals = { agents: 1, total: 5000, tokenTotal: 50000, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const tokenCard = cards.find((c) => c.label === 'Total Tokens');
-    assert.equal(tokenCard.value, '50,000');
+  it('shows 0 tokens when tokenTotal is missing', () => {
+    const cards = buildCardData([], {}, numberFmt);
+    const card = cards.find((c) => c.label === '전체 토큰');
+    assert.equal(card.value, '0');
   });
 
-  it('shows 0 for undefined numeric fields', () => {
-    const totals = {};
-    const cards = buildCardData(totals, numberFmt);
-    const activeCard = cards.find((c) => c.label === 'Active');
-    const errorCard = cards.find((c) => c.label === 'Error');
-    const tokenCard = cards.find((c) => c.label === 'Total Tokens');
-    const costCard = cards.find((c) => c.label === 'Cost (USD)');
-    assert.equal(activeCard.value, '0');
-    assert.equal(errorCard.value, '0');
-    assert.equal(tokenCard.value, '0');
-    assert.equal(costCard.value, '0.0000');
-  });
-
-  it('assigns error type to Error card when error > 0', () => {
-    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 1, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const errorCard = cards.find((c) => c.label === 'Error');
-    assert.equal(errorCard.type, 'error');
-  });
-
-  it('assigns neutral type to Error card when error is 0', () => {
-    const totals = { agents: 1, total: 1, tokenTotal: 0, ok: 0, warning: 0, error: 0, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const errorCard = cards.find((c) => c.label === 'Error');
-    assert.equal(errorCard.type, 'neutral');
-  });
-
-  it('assigns neutral type to Total Tokens and Cost cards', () => {
-    const totals = { agents: 1, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 1.5 };
-    const cards = buildCardData(totals, numberFmt);
-    for (const label of ['Total Tokens', 'Cost (USD)']) {
-      const card = cards.find((c) => c.label === label);
-      assert.equal(card.type, 'neutral', `${label} should have neutral type`);
-    }
-  });
-
-  it('includes Active card with ok type when activeAgents > 0', () => {
-    const totals = { agents: 2, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt, 2);
-    const activeCard = cards.find((c) => c.label === 'Active');
-    assert.ok(activeCard, 'Active card should exist');
-    assert.equal(activeCard.value, '2');
-    assert.equal(activeCard.type, 'ok');
-  });
-
-  it('includes Active card with neutral type when activeAgents is 0', () => {
-    const totals = { agents: 2, total: 5, tokenTotal: 100, ok: 3, warning: 1, error: 1, costTotalUsd: 0 };
-    const cards = buildCardData(totals, numberFmt, 0);
-    const activeCard = cards.find((c) => c.label === 'Active');
-    assert.ok(activeCard, 'Active card should exist');
-    assert.equal(activeCard.value, '0');
-    assert.equal(activeCard.type, 'neutral');
-  });
-
-  it('defaults activeAgents to 0 when not provided', () => {
-    const totals = { agents: 1, total: 0, tokenTotal: 0, ok: 0, warning: 0, error: 0 };
-    const cards = buildCardData(totals, numberFmt);
-    const activeCard = cards.find((c) => c.label === 'Active');
-    assert.ok(activeCard, 'Active card should exist');
-    assert.equal(activeCard.value, '0');
-    assert.equal(activeCard.type, 'neutral');
-  });
-
-  it('uses rangeInfo for Tokens card when provided', () => {
+  it('uses rangeInfo for token card label and value', () => {
     const totals = { tokenTotal: 9999, costTotalUsd: 5.0 };
     const rangeInfo = { label: '최근 1시간', tokenTotal: 100, costUsd: 0.05 };
-    const cards = buildCardData(totals, numberFmt, 0, rangeInfo);
-    const tokenCard = cards.find((c) => c.label === '최근 1시간 Tokens');
-    assert.ok(tokenCard, 'range Tokens card should exist');
-    assert.equal(tokenCard.value, '100');
+    const cards = buildCardData([], totals, numberFmt, rangeInfo);
+    const card = cards.find((c) => c.label === '최근 1시간 토큰');
+    assert.ok(card, 'range 토큰 card should exist');
+    assert.equal(card.value, '100');
   });
 
-  it('uses rangeInfo for Cost card when provided', () => {
+  it('uses rangeInfo for cost card label and value', () => {
     const totals = { tokenTotal: 9999, costTotalUsd: 5.0 };
     const rangeInfo = { label: '최근 1시간', tokenTotal: 100, costUsd: 0.05 };
-    const cards = buildCardData(totals, numberFmt, 0, rangeInfo);
-    const costCard = cards.find((c) => c.label === '최근 1시간 Cost');
-    assert.ok(costCard, 'range Cost card should exist');
-    assert.equal(costCard.value, '0.0500');
+    const cards = buildCardData([], totals, numberFmt, rangeInfo);
+    const card = cards.find((c) => c.label === '최근 1시간 비용');
+    assert.ok(card, 'range 비용 card should exist');
+    assert.equal(card.value, '0.0500');
   });
 
-  it('uses totals when rangeInfo is null', () => {
+  it('falls back to totals when rangeInfo is null', () => {
     const totals = { tokenTotal: 500, costTotalUsd: 1.5 };
-    const cards = buildCardData(totals, numberFmt, 0, null);
-    const tokenCard = cards.find((c) => c.label === 'Total Tokens');
-    assert.ok(tokenCard, 'Total Tokens card should exist');
-    assert.equal(tokenCard.value, '500');
+    const cards = buildCardData([], totals, numberFmt, null);
+    const card = cards.find((c) => c.label === '전체 토큰');
+    assert.ok(card, '전체 토큰 card should exist');
+    assert.equal(card.value, '500');
+  });
+
+  it('formats large token values with locale separators', () => {
+    const totals = { tokenTotal: 1234567 };
+    const cards = buildCardData([], totals, numberFmt);
+    const card = cards.find((c) => c.label === '전체 토큰');
+    assert.equal(card.value, '1,234,567');
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,7 @@
 import { recalcWorkflow, splitWorkflow } from './lib/workflow.js';
 import { buildCardData } from './lib/cards.js';
 import { sumByRange, rangeLabel } from './lib/time-range.js';
-import { escapeHtml, statusPill, getActivityStatus, activityDotHtml, countActiveAgents } from './lib/utils.js';
+import { escapeHtml, statusPill, getActivityStatus, activityDotHtml } from './lib/utils.js';
 import { applyIncrementalEvent } from './lib/state.js';
 import { saveFilters, loadFilters, saveToggle, loadToggle } from './lib/persistence.js';
 import { connectStream, loadSnapshot } from './lib/connection.js';
@@ -70,8 +70,7 @@ function queueRender() {
   });
 }
 
-function renderCards(totals, agents = [], buckets = [], startedAt = '') {
-  const activeAgents = countActiveAgents(agents);
+function renderCards(totals, sessionRows = [], buckets = [], startedAt = '') {
   const rangeResult = sumByRange(buckets, currentRange, Date.now());
   let rangeInfo = null;
   if (rangeResult) {
@@ -79,7 +78,7 @@ function renderCards(totals, agents = [], buckets = [], startedAt = '') {
   } else if (currentRange === 'all') {
     rangeInfo = { label: rangeLabel('all', startedAt), tokenTotal: totals.tokenTotal || 0, costUsd: totals.costTotalUsd || 0 };
   }
-  const cards = buildCardData(totals, numberFmt, activeAgents, rangeInfo);
+  const cards = buildCardData(sessionRows, totals, numberFmt, rangeInfo);
   cardsRoot.innerHTML = cards
     .map(
       (c) =>
@@ -118,7 +117,7 @@ function getFilters() {
 function renderSnapshot(snapshot) {
   snapshotState = snapshot;
   const sessionRows = annotateSessionsWithState(snapshot.sessions || [], snapshot.agents || []);
-  renderCards(snapshot.totals, snapshot.agents || [], snapshot.hourlyBuckets || [], snapshot.startedAt || '');
+  renderCards(snapshot.totals, sessionRows, snapshot.hourlyBuckets || [], snapshot.startedAt || '');
   populateAgentFilter(snapshot.agents || [], agentFilter);
   renderWorkflow(snapshot.workflowProgress || recalcWorkflow(snapshot.agents));
   renderAgents(snapshot.agents || [], agentsBody, agentFilter.value);
@@ -237,7 +236,8 @@ connectStream({
 
 setInterval(() => {
   if (!snapshotState || renderQueued) return;
-  renderCards(snapshotState.totals, snapshotState.agents || [], snapshotState.hourlyBuckets || [], snapshotState.startedAt || '');
+  const intervalSessionRows = annotateSessionsWithState(snapshotState.sessions || [], snapshotState.agents || []);
+  renderCards(snapshotState.totals, intervalSessionRows, snapshotState.hourlyBuckets || [], snapshotState.startedAt || '');
   renderWorkflow(snapshotState.workflowProgress || recalcWorkflow(snapshotState.agents));
   renderAgents(snapshotState.agents || [], agentsBody, agentFilter.value);
 }, 1000);

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,13 +1,18 @@
-export function buildCardData(totals, numberFmt, activeAgents = 0, rangeInfo = null) {
-  const tokenLabel = rangeInfo ? `${rangeInfo.label} Tokens` : 'Total Tokens';
+export function buildCardData(sessions = [], totals = {}, numberFmt, rangeInfo = null) {
+  const activeSessions = sessions.filter((s) => s.sessionState === 'active').length;
+  const needsAttention = sessions.filter(
+    (s) => s.sessionState === 'stuck' || s.sessionState === 'failed'
+  ).length;
+
+  const tokenLabel = rangeInfo ? `${rangeInfo.label} 토큰` : '전체 토큰';
   const tokenValue = rangeInfo ? rangeInfo.tokenTotal : (totals.tokenTotal || 0);
-  const costLabel = rangeInfo ? `${rangeInfo.label} Cost` : 'Cost (USD)';
+  const costLabel = rangeInfo ? `${rangeInfo.label} 비용` : '비용 (USD)';
   const costValue = rangeInfo ? rangeInfo.costUsd : (totals.costTotalUsd || 0);
 
   return [
-    { label: 'Active', value: numberFmt.format(activeAgents), type: activeAgents > 0 ? 'ok' : 'neutral' },
-    { label: 'Error', value: numberFmt.format(totals.error || 0), type: (totals.error || 0) > 0 ? 'error' : 'neutral' },
-    { label: 'Sessions', value: numberFmt.format(totals.sessions || 0), type: 'neutral' },
+    { label: '활성 세션', value: numberFmt.format(activeSessions), type: activeSessions > 0 ? 'ok' : 'neutral' },
+    { label: '주의 필요', value: numberFmt.format(needsAttention), type: needsAttention > 0 ? 'warning' : 'neutral' },
+    { label: '세션', value: numberFmt.format(sessions.length), type: 'neutral' },
     { label: tokenLabel, value: numberFmt.format(tokenValue), type: 'neutral' },
     { label: costLabel, value: Number(costValue).toFixed(4), type: 'neutral' }
   ];


### PR DESCRIPTION
## Summary
- shift top summary cards from agent metrics to session metrics
- add active and needs-attention session counts
- keep token and cost cards aligned with the selected time range

## Testing
- npm run check
- node --test public/__tests__/*.test.js

Closes #120