### PR TITLE
feat: detect stuck sessions and cost spikes

### DIFF
--- a/public/__tests__/cards.test.js
+++ b/public/__tests__/cards.test.js
@@ -5,6 +5,11 @@ import { buildCardData } from '../lib/cards.js';
 const numberFmt = new Intl.NumberFormat('ko-KR');
 
 const makeSessions = (states) => states.map((sessionState) => ({ sessionState }));
+const makeAttentionSession = (overrides = {}) => ({
+  sessionState: 'active',
+  needsAttention: false,
+  ...overrides
+});
 
 describe('buildCardData', () => {
   it('returns 5 cards total', () => {
@@ -43,10 +48,26 @@ describe('buildCardData', () => {
   });
 
   it('counts stuck + failed sessions as 주의 필요', () => {
-    const sessions = makeSessions(['active', 'stuck', 'failed', 'completed']);
+    const sessions = [
+      makeAttentionSession({ sessionState: 'active' }),
+      makeAttentionSession({ sessionState: 'stuck', needsAttention: true }),
+      makeAttentionSession({ sessionState: 'failed', needsAttention: true }),
+      makeAttentionSession({ sessionState: 'completed' })
+    ];
     const cards = buildCardData(sessions, {}, numberFmt);
     const card = cards.find((c) => c.label === '주의 필요');
     assert.equal(card.value, '2');
+    assert.equal(card.type, 'warning');
+  });
+
+  it('counts sessions with needsAttention even when state is active', () => {
+    const sessions = [
+      makeAttentionSession({ sessionState: 'active', needsAttention: true }),
+      makeAttentionSession({ sessionState: 'completed', needsAttention: false })
+    ];
+    const cards = buildCardData(sessions, {}, numberFmt);
+    const card = cards.find((c) => c.label === '주의 필요');
+    assert.equal(card.value, '1');
     assert.equal(card.type, 'warning');
   });
 

--- a/public/__tests__/session-status.test.js
+++ b/public/__tests__/session-status.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { annotateSessionsWithState, deriveSessionState, toWorkflowStatus } from '../lib/session-status.js';
+import { annotateSessionsWithState, deriveRiskSignals, deriveSessionState, toWorkflowStatus } from '../lib/session-status.js';
 
 describe('deriveSessionState', () => {
   it('returns failed when error count is present', () => {
@@ -62,6 +62,47 @@ describe('toWorkflowStatus', () => {
   });
 });
 
+describe('deriveRiskSignals', () => {
+  it('marks failed sessions as needing attention', () => {
+    const signals = deriveRiskSignals({ sessionState: 'failed', warning: 0, costUsd: 0.01, tokenTotal: 100 });
+    assert.equal(signals.needsAttention, true);
+    assert.deepEqual(signals.needsAttentionReasons, ['failed']);
+    assert.equal(signals.needsAttentionRank, 400);
+    assert.equal(signals.isCostSpike, false);
+  });
+
+  it('marks stuck sessions as needing attention', () => {
+    const signals = deriveRiskSignals({ sessionState: 'stuck', warning: 0, costUsd: 0.01, tokenTotal: 100 });
+    assert.equal(signals.needsAttention, true);
+    assert.deepEqual(signals.needsAttentionReasons, ['stuck']);
+    assert.equal(signals.needsAttentionRank, 300);
+  });
+
+  it('marks high-cost sessions as cost spikes even when active', () => {
+    const signals = deriveRiskSignals({ sessionState: 'active', warning: 0, costUsd: 0.75, tokenTotal: 100 });
+    assert.equal(signals.needsAttention, true);
+    assert.deepEqual(signals.needsAttentionReasons, ['cost_spike']);
+    assert.equal(signals.needsAttentionRank, 100);
+    assert.equal(signals.isCostSpike, true);
+  });
+
+  it('sums composite reasons in priority order', () => {
+    const signals = deriveRiskSignals({ sessionState: 'stuck', warning: 1, costUsd: 0.75, tokenTotal: 25_000 });
+    assert.equal(signals.needsAttention, true);
+    assert.deepEqual(signals.needsAttentionReasons, ['stuck', 'warning', 'cost_spike']);
+    assert.equal(signals.needsAttentionRank, 600);
+    assert.equal(signals.isCostSpike, true);
+  });
+
+  it('falls back to low-risk values when data is sparse', () => {
+    const signals = deriveRiskSignals({ sessionState: 'idle', warning: 0, costUsd: 0, tokenTotal: 0 });
+    assert.equal(signals.needsAttention, false);
+    assert.deepEqual(signals.needsAttentionReasons, []);
+    assert.equal(signals.needsAttentionRank, 0);
+    assert.equal(signals.isCostSpike, false);
+  });
+});
+
 describe('annotateSessionsWithState', () => {
   it('aggregates agent totals by session and annotates active state', () => {
     const sessions = [{ sessionId: 'sess-1', lastSeen: '2026-01-01T00:00:00Z', tokenTotal: 100, costUsd: 0.01, agentIds: ['a1', 'a2'] }];
@@ -75,6 +116,10 @@ describe('annotateSessionsWithState', () => {
     assert.equal(rows[0].warning, 0);
     assert.equal(rows[0].error, 0);
     assert.equal(rows[0].sessionState, 'active');
+    assert.equal(rows[0].needsAttention, false);
+    assert.equal(rows[0].needsAttentionRank, 0);
+    assert.deepEqual(rows[0].needsAttentionReasons, []);
+    assert.equal(rows[0].isCostSpike, false);
   });
 
   it('marks a session as stuck when any agent warning exists', () => {
@@ -83,5 +128,20 @@ describe('annotateSessionsWithState', () => {
     const rows = annotateSessionsWithState(sessions, agents);
 
     assert.equal(rows[0].sessionState, 'stuck');
+    assert.equal(rows[0].needsAttention, true);
+    assert.equal(rows[0].needsAttentionRank, 500);
+    assert.deepEqual(rows[0].needsAttentionReasons, ['stuck', 'warning']);
+  });
+
+  it('marks a session as a cost spike from accumulated session fields', () => {
+    const sessions = [{ sessionId: 'sess-1', lastSeen: '2026-01-01T00:00:00Z', tokenTotal: 21_000, costUsd: 0.51, agentIds: ['a1'] }];
+    const agents = [{ agentId: 'a1', sessionId: 'sess-1', total: 2, warning: 0, error: 0 }];
+    const rows = annotateSessionsWithState(sessions, agents, new Date('2026-01-01T00:00:10Z').getTime());
+
+    assert.equal(rows[0].sessionState, 'active');
+    assert.equal(rows[0].needsAttention, true);
+    assert.equal(rows[0].isCostSpike, true);
+    assert.equal(rows[0].needsAttentionRank, 100);
+    assert.deepEqual(rows[0].needsAttentionReasons, ['cost_spike']);
   });
 });

--- a/public/lib/cards.js
+++ b/public/lib/cards.js
@@ -1,8 +1,6 @@
 export function buildCardData(sessions = [], totals = {}, numberFmt, rangeInfo = null) {
   const activeSessions = sessions.filter((s) => s.sessionState === 'active').length;
-  const needsAttention = sessions.filter(
-    (s) => s.sessionState === 'stuck' || s.sessionState === 'failed'
-  ).length;
+  const needsAttention = sessions.filter((s) => Boolean(s.needsAttention)).length;
 
   const tokenLabel = rangeInfo ? `${rangeInfo.label} 토큰` : '전체 토큰';
   const tokenValue = rangeInfo ? rangeInfo.tokenTotal : (totals.tokenTotal || 0);

--- a/public/lib/session-status.js
+++ b/public/lib/session-status.js
@@ -1,5 +1,14 @@
 const ACTIVE_WINDOW_MS = 30_000;
 const COMPLETED_WINDOW_MS = 120_000;
+const COST_SPIKE_USD_THRESHOLD = 0.5;
+const COST_SPIKE_TOKEN_THRESHOLD = 20_000;
+
+const NEEDS_ATTENTION_SCORES = {
+  failed: 400,
+  stuck: 300,
+  warning: 200,
+  cost_spike: 100
+};
 
 export function elapsedSince(lastSeen, now = Date.now()) {
   if (!lastSeen) return null;
@@ -18,6 +27,44 @@ export function deriveSessionState(row = {}, now = Date.now()) {
   if (elapsed !== null && total > 0 && elapsed < ACTIVE_WINDOW_MS) return 'active';
   if (elapsed !== null && total > 0 && elapsed >= COMPLETED_WINDOW_MS) return 'completed';
   return 'idle';
+}
+
+function orderedReasons(reasons = []) {
+  const seen = new Set();
+  const result = [];
+  for (const reason of ['failed', 'stuck', 'warning', 'cost_spike']) {
+    if (reasons.includes(reason) && !seen.has(reason)) {
+      seen.add(reason);
+      result.push(reason);
+    }
+  }
+  return result;
+}
+
+export function deriveRiskSignals(row = {}, now = Date.now()) {
+  const sessionState = row.sessionState || deriveSessionState(row, now);
+  const warning = Number(row.warning) || 0;
+  const costUsd = Number(row.costUsd) || 0;
+  const tokenTotal = Number(row.tokenTotal) || 0;
+  const isCostSpike = costUsd >= COST_SPIKE_USD_THRESHOLD || tokenTotal >= COST_SPIKE_TOKEN_THRESHOLD;
+
+  const reasons = [];
+  if (sessionState === 'failed') reasons.push('failed');
+  if (sessionState === 'stuck') reasons.push('stuck');
+  if (warning > 0) reasons.push('warning');
+  if (isCostSpike) reasons.push('cost_spike');
+
+  const needsAttentionReasons = orderedReasons(reasons);
+  const needsAttentionRank = needsAttentionReasons
+    .reduce((sum, reason) => sum + (NEEDS_ATTENTION_SCORES[reason] || 0), 0);
+
+  return {
+    sessionState,
+    needsAttention: needsAttentionRank > 0,
+    needsAttentionRank,
+    needsAttentionReasons,
+    isCostSpike
+  };
 }
 
 export function toWorkflowStatus(sessionState) {
@@ -50,20 +97,31 @@ export function annotateSessionsWithState(sessions = [], agents = [], now = Date
 
   return sessions.map((session) => {
     const totals = totalsBySession.get(session.sessionId) || { total: 0, warning: 0, error: 0 };
+    const derivedState = deriveSessionState(
+      {
+        total: totals.total,
+        warning: totals.warning,
+        error: totals.error,
+        lastSeen: session.lastSeen
+      },
+      now
+    );
+    const riskSignals = deriveRiskSignals(
+      {
+        ...session,
+        total: totals.total,
+        warning: totals.warning,
+        error: totals.error,
+        sessionState: derivedState
+      },
+      now
+    );
     return {
       ...session,
       total: totals.total,
       warning: totals.warning,
       error: totals.error,
-      sessionState: deriveSessionState(
-        {
-          total: totals.total,
-          warning: totals.warning,
-          error: totals.error,
-          lastSeen: session.lastSeen
-        },
-        now
-      )
+      ...riskSignals
     };
   });
 }


### PR DESCRIPTION
## Summary
- add shared risk signal fields for session rows, including attention rank and reasons
- flag cost spikes from session totals and use those fields in the top summary cards
- cover the new risk heuristics with session-status and cards tests

## Testing
- npm run check
- npm run test:js

Closes #125