### PR TITLE
refactor: move sessions into a workspace

### DIFF
--- a/public/__tests__/sessions.test.js
+++ b/public/__tests__/sessions.test.js
@@ -1,9 +1,9 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getSessionExportAttrs, renderSessionsList, renderSessionDetail } from '../lib/renders/sessions.js';
+import { getSessionExportAttrs, renderSessionsList, renderSessionDetail, renderSessionDetailMeta } from '../lib/renders/sessions.js';
 
 function makeRoot() {
-  return { innerHTML: '', dataset: {} };
+  return { innerHTML: '', dataset: {}, onclick: null };
 }
 
 const baseSessions = [
@@ -42,6 +42,11 @@ describe('renderSessionsList', () => {
     assert.ok(root.innerHTML.includes('data-status="active"'));
     assert.ok(root.innerHTML.includes('data-status="completed"'));
   });
+
+  it('marks the selected session row', () => {
+    renderSessionsList(baseSessions, root, () => {}, { selectedSessionId: 's2' });
+    assert.ok(root.innerHTML.includes('session-item--selected'));
+  });
 });
 
 describe('renderSessionDetail', () => {
@@ -60,6 +65,32 @@ describe('renderSessionDetail', () => {
   it('renders empty message when no events', () => {
     renderSessionDetail([], root);
     assert.ok(root.innerHTML.includes('이벤트 없음'));
+  });
+});
+
+describe('renderSessionDetailMeta', () => {
+  let root;
+  beforeEach(() => { root = makeRoot(); });
+
+  it('renders empty workspace guidance when no session is selected', () => {
+    renderSessionDetailMeta(null, root);
+    assert.ok(root.innerHTML.includes('세션을 선택하세요'));
+  });
+
+  it('renders summary stats and attention reasons for the selected session', () => {
+    renderSessionDetailMeta({
+      sessionId: 's1',
+      sessionState: 'failed',
+      lastSeen: '2025-01-01T00:00:10Z',
+      tokenTotal: 500,
+      costUsd: 0.05,
+      agentIds: ['a1', 'a2'],
+      needsAttentionRank: 400,
+      needsAttentionReasons: ['failed']
+    }, root);
+    assert.ok(root.innerHTML.includes('Attention Rank'));
+    assert.ok(root.innerHTML.includes('오류 발생'));
+    assert.ok(root.innerHTML.includes('data-status="failed"'));
   });
 });
 

--- a/public/app.js
+++ b/public/app.js
@@ -12,7 +12,13 @@ import { getFilteredEvents, renderEventMeta, renderEvents } from './lib/renders/
 import { renderAgents, populateAgentFilter, toggleAgentTreeNode } from './lib/renders/agents.js';
 import { renderAlerts } from './lib/renders/alerts.js';
 import { renderTimeline } from './lib/renders/timeline.js';
-import { renderSessionsList, renderSessionDetail, fetchSessionEvents, getSessionExportAttrs } from './lib/renders/sessions.js';
+import {
+  renderSessionsList,
+  renderSessionDetail,
+  renderSessionDetailMeta,
+  fetchSessionEvents,
+  getSessionExportAttrs
+} from './lib/renders/sessions.js';
 import { isEmptySnapshot, renderEmptyState } from './lib/empty-state.js';
 
 const cardsRoot = document.getElementById('cards');
@@ -36,6 +42,7 @@ const sessionsListRoot = document.getElementById('sessionsList');
 const sessionDetailRoot = document.getElementById('sessionDetail');
 const sessionDetailBack = document.getElementById('sessionDetailBack');
 const sessionDetailTitle = document.getElementById('sessionDetailTitle');
+const sessionDetailMeta = document.getElementById('sessionDetailMeta');
 const sessionDetailExport = document.getElementById('sessionDetailExport');
 const sessionDetailEvents = document.getElementById('sessionDetailEvents');
 
@@ -63,6 +70,9 @@ let currentRange = localStorage.getItem(RANGE_KEY) || '1h';
 const storageKey = 'agent_monitor_event_filters_v1';
 const WORKFLOW_TOGGLE_KEY = 'agent_monitor_workflow_toggle_v1';
 let showCompleted = loadToggle(WORKFLOW_TOGGLE_KEY);
+let selectedSessionId = '';
+const sessionEventsCache = new Map();
+let sessionDetailState = { sessionId: '', loading: false, error: false };
 
 function queueRender() {
   if (renderQueued) return;
@@ -127,6 +137,7 @@ function renderSnapshot(snapshot) {
     if (empty) renderEmptyState(emptyStateEl);
   }
   const sessionRows = annotateSessionsWithState(snapshot.sessions || [], snapshot.agents || []);
+  const selectedSession = resolveSelectedSession(sessionRows);
   renderCards(snapshot.totals, sessionRows, snapshot.hourlyBuckets || [], snapshot.startedAt || '');
   renderNeedsAttention(sessionRows, needsAttentionRoot, openSessionDetail);
   populateAgentFilter(snapshot.agents || [], agentFilter);
@@ -139,12 +150,51 @@ function renderSnapshot(snapshot) {
   renderEvents(filteredEvents, eventsRoot);
   renderEventMeta(allEvents.length, filteredEvents.length, eventMetaEl);
   renderAlerts(snapshot.alerts || [], alertsRoot, alertDrilldownRoot, snapshot);
-  if (!sessionDetailRoot.hidden) {
-    // keep detail view open; don't overwrite
-  } else {
-    renderSessionsList(sessionRows, sessionsListRoot, openSessionDetail);
+  renderSessionsList(sessionRows, sessionsListRoot, openSessionDetail, { selectedSessionId });
+  if (selectedSession && !sessionEventsCache.has(selectedSession.sessionId) && sessionDetailState.sessionId !== selectedSession.sessionId) {
+    openSessionDetail(selectedSession.sessionId);
   }
+  renderSelectedSessionDetail(selectedSession);
   clock.textContent = `마지막 갱신 ${new Date(snapshot.generatedAt).toLocaleTimeString()}`;
+}
+
+function resolveSelectedSession(sessionRows = []) {
+  const hasSelected = selectedSessionId && sessionRows.some((row) => row.sessionId === selectedSessionId);
+  if (hasSelected) {
+    return sessionRows.find((row) => row.sessionId === selectedSessionId) || null;
+  }
+  selectedSessionId = sessionRows[0]?.sessionId || '';
+  return sessionRows[0] || null;
+}
+
+function renderSelectedSessionDetail(session) {
+  sessionDetailTitle.textContent = session?.sessionId || '선택된 세션 없음';
+  renderSessionDetailMeta(session, sessionDetailMeta);
+  const hasSession = Boolean(session?.sessionId);
+  sessionDetailBack.hidden = !hasSession;
+  sessionDetailExport.hidden = !hasSession;
+  if (!hasSession) {
+    sessionDetailExport.removeAttribute('href');
+    sessionDetailExport.removeAttribute('download');
+    sessionDetailEvents.innerHTML = '<p class="sessions-empty">선택된 세션이 없습니다.</p>';
+    return;
+  }
+
+  const attrs = getSessionExportAttrs(session.sessionId);
+  sessionDetailExport.href = attrs.href;
+  sessionDetailExport.download = attrs.download;
+
+  if (sessionDetailState.loading && sessionDetailState.sessionId === session.sessionId) {
+    sessionDetailEvents.innerHTML = '<p>이벤트를 불러오는 중...</p>';
+    return;
+  }
+
+  if (sessionDetailState.error && sessionDetailState.sessionId === session.sessionId) {
+    sessionDetailEvents.innerHTML = '<p>이벤트를 불러올 수 없습니다.</p>';
+    return;
+  }
+
+  renderSessionDetail(sessionEventsCache.get(session.sessionId) || [], sessionDetailEvents);
 }
 
 function doSaveFilters() {
@@ -168,32 +218,27 @@ function refilterEvents() {
 }
 
 function openSessionDetail(sessionId) {
-  sessionsListRoot.hidden = true;
-  sessionDetailRoot.hidden = false;
-  sessionDetailTitle.textContent = sessionId;
-  if (sessionDetailExport) {
-    const attrs = getSessionExportAttrs(sessionId);
-    sessionDetailExport.href = attrs.href;
-    sessionDetailExport.download = attrs.download;
-  }
-  sessionDetailEvents.innerHTML = '<p>로딩 중...</p>';
+  selectedSessionId = sessionId;
+  sessionDetailState = { sessionId, loading: true, error: false };
+  queueRender();
   fetchSessionEvents(sessionId).then((events) => {
-    renderSessionDetail(events, sessionDetailEvents);
+    sessionEventsCache.set(sessionId, events);
+    if (selectedSessionId === sessionId) {
+      sessionDetailState = { sessionId, loading: false, error: false };
+      queueRender();
+    }
   }).catch(() => {
-    sessionDetailEvents.innerHTML = '<p>이벤트를 불러올 수 없습니다.</p>';
+    if (selectedSessionId === sessionId) {
+      sessionDetailState = { sessionId, loading: false, error: true };
+      queueRender();
+    }
   });
 }
 
 sessionDetailBack.addEventListener('click', () => {
-  sessionDetailRoot.hidden = true;
-  sessionsListRoot.hidden = false;
-  if (snapshotState) {
-    renderSessionsList(
-      annotateSessionsWithState(snapshotState.sessions || [], snapshotState.agents || []),
-      sessionsListRoot,
-      openSessionDetail
-    );
-  }
+  selectedSessionId = '';
+  sessionDetailState = { sessionId: '', loading: false, error: false };
+  queueRender();
 });
 
 workflowToggle.addEventListener('click', () => {

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,27 @@
         <div id="needsAttention" class="needs-attention-list"></div>
       </section>
 
+      <section class="panel" id="sessionsPanel">
+        <div class="panel-head">
+          <h2>Sessions Workspace</h2>
+          <small>세션 선택과 상세 진단을 먼저 수행하는 작업면</small>
+        </div>
+        <div class="session-workspace">
+          <div id="sessionsList" class="sessions-list"></div>
+          <div id="sessionDetail" class="session-detail">
+            <div class="session-detail-head">
+              <button id="sessionDetailBack" class="session-back-btn" type="button">&larr; 선택 해제</button>
+              <span id="sessionDetailTitle" class="session-detail-title"></span>
+              <a id="sessionDetailExport" class="session-export-btn" href="#" download title="현재 세션을 로컬 JSON으로 저장">
+                Export JSON
+              </a>
+            </div>
+            <div id="sessionDetailMeta" class="session-detail-meta"></div>
+            <div id="sessionDetailEvents" class="events session-detail-events"></div>
+          </div>
+        </div>
+      </section>
+
       <section class="panel">
         <div class="panel-head">
           <h2>세션 타임라인</h2>
@@ -75,21 +96,6 @@
         </div>
         <div class="workflow" id="workflow"></div>
         <div id="workflowCompleted" class="workflow-completed"></div>
-      </section>
-
-      <section class="panel" id="sessionsPanel">
-        <h2>세션 드릴다운</h2>
-        <div id="sessionsList" class="sessions-list"></div>
-        <div id="sessionDetail" class="session-detail" hidden>
-          <div class="session-detail-head">
-            <button id="sessionDetailBack" class="session-back-btn">&larr; 목록으로</button>
-            <span id="sessionDetailTitle" class="session-detail-title"></span>
-            <a id="sessionDetailExport" class="session-export-btn" href="#" download title="현재 세션을 로컬 JSON으로 저장">
-              Export JSON
-            </a>
-          </div>
-          <div id="sessionDetailEvents" class="events"></div>
-        </div>
       </section>
 
       <section class="panel">

--- a/public/lib/renders/sessions.js
+++ b/public/lib/renders/sessions.js
@@ -1,6 +1,29 @@
 import { escapeHtml, relativeTime, statusPill } from '../utils.js';
 
-export function renderSessionsList(sessions, root, onSelect) {
+const REASON_LABELS = {
+  failed: '오류 발생',
+  stuck: '응답 지연',
+  warning: '경고 누적',
+  cost_spike: '비용 급증'
+};
+
+function sessionReasonBadges(session = {}) {
+  const reasons = Array.isArray(session.needsAttentionReasons) ? session.needsAttentionReasons : [];
+  if (!reasons.length) return '';
+  return `<div class="session-item-reasons">${reasons
+    .map((reason) => `<span class="attention-reason attention-reason--${escapeHtml(reason)}">${escapeHtml(REASON_LABELS[reason] || reason)}</span>`)
+    .join('')}</div>`;
+}
+
+function sessionMetaHtml(session = {}) {
+  return `<span>tokens: ${Number(session.tokenTotal || 0)}</span>
+    <span>cost: $${Number(session.costUsd || 0).toFixed(4)}</span>
+    <span>agents: ${Array.isArray(session.agentIds) ? session.agentIds.length : 0}</span>
+    <span>last: ${relativeTime(session.lastSeen)}</span>`;
+}
+
+export function renderSessionsList(sessions, root, onSelect, options = {}) {
+  const { selectedSessionId = '' } = options;
   if (!sessions || sessions.length === 0) {
     root.innerHTML = `<p class="sessions-empty">아직 세션이 없습니다. Claude Code를 실행하면 세션이 여기에 표시됩니다.<br><small>수집 경로: <code>~/.claude/projects/</code></small></p>`;
     return;
@@ -8,17 +31,15 @@ export function renderSessionsList(sessions, root, onSelect) {
 
   root.innerHTML = sessions
     .map(
-      (s) => `<div class="session-item" data-session-id="${escapeHtml(s.sessionId)}">
+      (s) => `<div class="session-item${s.sessionId === selectedSessionId ? ' session-item--selected' : ''}" data-session-id="${escapeHtml(s.sessionId)}">
         <div class="session-item-main">
           <div class="session-item-id">${escapeHtml(s.sessionId)}</div>
           ${statusPill(s.sessionState || 'idle')}
         </div>
         <div class="session-item-meta">
-          <span>tokens: ${s.tokenTotal}</span>
-          <span>cost: $${s.costUsd.toFixed(4)}</span>
-          <span>agents: ${s.agentIds.length}</span>
-          <span>last: ${relativeTime(s.lastSeen)}</span>
+          ${sessionMetaHtml(s)}
         </div>
+        ${sessionReasonBadges(s)}
       </div>`
     )
     .join('');
@@ -48,6 +69,39 @@ export function renderSessionDetail(events, root) {
       </div>`
     )
     .join('');
+}
+
+function summaryStat(label, value) {
+  return `<div class="session-detail-stat">
+    <div class="session-detail-stat-label">${escapeHtml(label)}</div>
+    <div class="session-detail-stat-value">${escapeHtml(value)}</div>
+  </div>`;
+}
+
+export function renderSessionDetailMeta(session, root) {
+  if (!session) {
+    root.innerHTML = `<div class="session-detail-empty">
+      <strong>세션을 선택하세요</strong>
+      <p>문제 세션을 선택하면 상태, 비용, 이벤트를 이 영역에서 바로 진단할 수 있습니다.</p>
+    </div>`;
+    return;
+  }
+
+  const reasonBadges = sessionReasonBadges(session);
+  root.innerHTML = `
+    <div class="session-detail-summary">
+      <div class="session-detail-summary-main">
+        ${statusPill(session.sessionState || 'idle')}
+        <span class="session-detail-summary-last">마지막 활동 ${escapeHtml(relativeTime(session.lastSeen))}</span>
+      </div>
+      ${reasonBadges}
+      <div class="session-detail-stats">
+        ${summaryStat('Tokens', String(Number(session.tokenTotal || 0)))}
+        ${summaryStat('Cost', `$${Number(session.costUsd || 0).toFixed(4)}`)}
+        ${summaryStat('Agents', String(Array.isArray(session.agentIds) ? session.agentIds.length : 0))}
+        ${summaryStat('Attention Rank', String(Number(session.needsAttentionRank || 0)))}
+      </div>
+    </div>`;
 }
 
 function sanitizeExportSegment(value) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -814,6 +814,20 @@ tbody tr:hover td {
     gap: 4px;
   }
 
+  .session-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .sessions-list,
+  .session-detail {
+    max-height: none;
+    min-height: 0;
+  }
+
+  .session-detail-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .attention-item-main {
     flex-direction: column;
   }
@@ -844,6 +858,10 @@ tbody tr:hover td {
 @media (max-width: 480px) {
   .cards {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .session-detail-stats {
+    grid-template-columns: 1fr;
   }
 
   h1 {
@@ -1120,10 +1138,19 @@ tr.tree-last .tree-branch::before {
 
 /* ── Session drill-down ── */
 
+.session-workspace {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
 .sessions-list {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  max-height: 520px;
+  overflow-y: auto;
 }
 
 .sessions-empty {
@@ -1148,6 +1175,11 @@ tr.tree-last .tree-branch::before {
   box-shadow: 0 2px 8px var(--shadow-hover-subtle);
 }
 
+.session-item--selected {
+  border-color: var(--warm);
+  box-shadow: 0 0 0 2px var(--border-medium);
+}
+
 .session-item-main {
   display: flex;
   align-items: center;
@@ -1166,9 +1198,26 @@ tr.tree-last .tree-branch::before {
 
 .session-item-meta {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   font-size: 12px;
   color: var(--chart-sublabel);
+}
+
+.session-item-reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.session-detail {
+  min-height: 520px;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--surface-card);
 }
 
 .session-detail-head {
@@ -1184,6 +1233,71 @@ tr.tree-last .tree-branch::before {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-detail-meta {
+  margin-bottom: 12px;
+}
+
+.session-detail-summary {
+  display: grid;
+  gap: 10px;
+}
+
+.session-detail-summary-main {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.session-detail-summary-last {
+  font-size: 12px;
+  color: var(--chart-sublabel);
+}
+
+.session-detail-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.session-detail-stat {
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.session-detail-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.62;
+}
+
+.session-detail-stat-value {
+  margin-top: 4px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.session-detail-empty {
+  padding: 14px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+}
+
+.session-detail-empty strong,
+.session-detail-empty p {
+  margin: 0;
+}
+
+.session-detail-empty p {
+  margin-top: 6px;
+  color: var(--chart-sublabel);
+  font-size: 13px;
 }
 
 .session-back-btn,
@@ -1205,6 +1319,10 @@ tr.tree-last .tree-branch::before {
 .session-back-btn:hover,
 .session-export-btn:hover {
   background: var(--hover-overlay);
+}
+
+.session-detail-events {
+  flex: 1 1 auto;
 }
 
 /* ── Empty / first-run state ── */


### PR DESCRIPTION
## Summary
- move the sessions workspace directly below Needs Attention and keep list/detail visible together
- preserve the selected session across rerenders and show summary metadata in the detail pane
- add session workspace tests for selected rows and detail meta rendering

## Testing
- npm run check
- npm run test:js

Closes #122