### PR TITLE
feat: link alerts to session detail

### DIFF
--- a/public/__tests__/alerts.test.js
+++ b/public/__tests__/alerts.test.js
@@ -1,6 +1,13 @@
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { alertItemHtml, getAlertContext, drilldownHtml, resetAlertSelection } from '../lib/renders/alerts.js';
+import {
+  alertItemHtml,
+  getAlertContext,
+  drilldownHtml,
+  renderAlerts,
+  resolveAlertSessionId,
+  resetAlertSelection
+} from '../lib/renders/alerts.js';
 
 function makeAlert(overrides = {}) {
   return {
@@ -77,6 +84,31 @@ describe('alertItemHtml', () => {
     assert.ok(!html.includes('"><b>'));
     assert.ok(html.includes('&lt;script&gt;'));
   });
+
+  it('includes linked session id when available', () => {
+    const html = alertItemHtml(makeAlert(), false, 'sess-1');
+    assert.ok(html.includes('data-session-id="sess-1"'));
+  });
+});
+
+describe('resolveAlertSessionId', () => {
+  it('prefers agent state session id', () => {
+    const alert = makeAlert();
+    const snapshot = makeSnapshot({
+      agents: [{ agentId: 'agent-abc', sessionId: 'sess-agent' }],
+      recent: [{ agentId: 'agent-abc', sessionId: 'sess-event' }]
+    });
+    assert.equal(resolveAlertSessionId(alert, snapshot), 'sess-agent');
+  });
+
+  it('falls back to recent event session id', () => {
+    const alert = makeAlert();
+    const snapshot = makeSnapshot({
+      agents: [],
+      recent: [{ agentId: 'agent-abc', sessionId: 'sess-event' }]
+    });
+    assert.equal(resolveAlertSessionId(alert, snapshot), 'sess-event');
+  });
 });
 
 // ── getAlertContext ──
@@ -121,7 +153,15 @@ describe('getAlertContext', () => {
 
   it('returns empty context when snapshot is null', () => {
     const ctx = getAlertContext('agent-abc', null);
-    assert.deepEqual(ctx, { recentEvents: [], agentState: null });
+    assert.deepEqual(ctx, { recentEvents: [], agentState: null, linkedSessionId: '' });
+  });
+
+  it('includes linked session id in context when available', () => {
+    const snapshot = makeSnapshot({
+      agents: [{ agentId: 'agent-abc', sessionId: 'sess-1' }]
+    });
+    const ctx = getAlertContext('agent-abc', snapshot);
+    assert.equal(ctx.linkedSessionId, 'sess-1');
   });
 });
 
@@ -180,5 +220,103 @@ describe('drilldownHtml', () => {
   it('shows empty state message when no context events', () => {
     const html = drilldownHtml(makeAlert(), { recentEvents: [], agentState: null });
     assert.ok(html.includes('data-drilldown-close'));
+  });
+
+  it('includes linked session section and open button when session exists', () => {
+    const html = drilldownHtml(makeAlert(), { recentEvents: [], agentState: null, linkedSessionId: 'sess-1' });
+    assert.ok(html.includes('Linked Session'));
+    assert.ok(html.includes('data-session-open="sess-1"'));
+  });
+});
+
+describe('renderAlerts', () => {
+  beforeEach(() => {
+    resetAlertSelection();
+  });
+
+  function makeAlertsRoot() {
+    return {
+      innerHTML: '',
+      onclick: null,
+      querySelectorAll() {
+        return [];
+      }
+    };
+  }
+
+  function makeDrilldownRoot() {
+    return {
+      innerHTML: '',
+      hidden: true,
+      onclick: null,
+      setAttribute(name) {
+        if (name === 'hidden') this.hidden = true;
+      },
+      removeAttribute(name) {
+        if (name === 'hidden') this.hidden = false;
+      }
+    };
+  }
+
+  it('opens linked session on primary alert click when a session is resolvable', () => {
+    const alertsRoot = makeAlertsRoot();
+    const drilldownRoot = makeDrilldownRoot();
+    const snapshot = makeSnapshot({
+      agents: [{ agentId: 'agent-abc', sessionId: 'sess-1' }]
+    });
+    let openedSessionId = '';
+
+    renderAlerts([makeAlert()], alertsRoot, drilldownRoot, snapshot, {
+      onOpenSession(sessionId) {
+        openedSessionId = sessionId;
+      }
+    });
+
+    alertsRoot.onclick({
+      target: {
+        closest(selector) {
+          if (selector === '[data-alert-id]') {
+            return {
+              dataset: { alertId: 'alert-1', sessionId: 'sess-1' },
+              classList: { add() {}, remove() {} }
+            };
+          }
+          return null;
+        }
+      }
+    });
+
+    assert.equal(openedSessionId, 'sess-1');
+    assert.equal(drilldownRoot.hidden, false);
+    assert.ok(drilldownRoot.innerHTML.includes('sess-1'));
+  });
+
+  it('keeps drilldown-only behavior when no linked session exists', () => {
+    const alertsRoot = makeAlertsRoot();
+    const drilldownRoot = makeDrilldownRoot();
+    let openedSessionId = '';
+
+    renderAlerts([makeAlert()], alertsRoot, drilldownRoot, makeSnapshot(), {
+      onOpenSession(sessionId) {
+        openedSessionId = sessionId;
+      }
+    });
+
+    alertsRoot.onclick({
+      target: {
+        closest(selector) {
+          if (selector === '[data-alert-id]') {
+            return {
+              dataset: { alertId: 'alert-1' },
+              classList: { add() {}, remove() {} }
+            };
+          }
+          return null;
+        }
+      }
+    });
+
+    assert.equal(openedSessionId, '');
+    assert.equal(drilldownRoot.hidden, false);
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -149,7 +149,7 @@ function renderSnapshot(snapshot) {
   const filteredEvents = getFilteredEvents(allEvents, getFilters());
   renderEvents(filteredEvents, eventsRoot);
   renderEventMeta(allEvents.length, filteredEvents.length, eventMetaEl);
-  renderAlerts(snapshot.alerts || [], alertsRoot, alertDrilldownRoot, snapshot);
+  renderAlerts(snapshot.alerts || [], alertsRoot, alertDrilldownRoot, snapshot, { onOpenSession: openSessionDetail });
   renderSessionsList(sessionRows, sessionsListRoot, openSessionDetail, { selectedSessionId });
   if (selectedSession && !sessionEventsCache.has(selectedSession.sessionId) && sessionDetailState.sessionId !== selectedSession.sessionId) {
     openSessionDetail(selectedSession.sessionId);

--- a/public/lib/renders/alerts.js
+++ b/public/lib/renders/alerts.js
@@ -7,10 +7,18 @@ export function resetAlertSelection() {
   _selectedAlertId = null;
 }
 
-export function alertItemHtml(alert, isSelected = false) {
+export function resolveAlertSessionId(alert = {}, snapshot) {
+  if (!snapshot || !alert.agentId) return '';
+  const agentState = (snapshot.agents || []).find((agent) => agent.agentId === alert.agentId);
+  if (agentState?.sessionId) return agentState.sessionId;
+  const recentEvent = (snapshot.recent || []).find((event) => event.agentId === alert.agentId && event.sessionId);
+  return recentEvent?.sessionId || '';
+}
+
+export function alertItemHtml(alert, isSelected = false, sessionId = '') {
   const cls = isSelected ? 'event alert-item alert-item--selected' : 'event alert-item';
   return `
-      <div class="${cls}" data-alert-id="${escapeHtml(alert.id)}">
+      <div class="${cls}" data-alert-id="${escapeHtml(alert.id)}"${sessionId ? ` data-session-id="${escapeHtml(sessionId)}"` : ''}>
         <span>${new Date(alert.createdAt).toLocaleTimeString()}</span>
         <span title="${escapeHtml(alert.agentId)}"><strong>${escapeHtml(displayNameFor(alert.agentId))}</strong></span>
         <span>${escapeHtml(alert.event)}</span>
@@ -20,16 +28,17 @@ export function alertItemHtml(alert, isSelected = false) {
 }
 
 export function getAlertContext(agentId, snapshot) {
-  if (!snapshot) return { recentEvents: [], agentState: null };
+  if (!snapshot) return { recentEvents: [], agentState: null, linkedSessionId: '' };
   const recentEvents = (snapshot.recent || [])
     .filter((e) => e.agentId === agentId)
     .slice(0, 5);
   const agentState = (snapshot.agents || []).find((a) => a.agentId === agentId) || null;
-  return { recentEvents, agentState };
+  const linkedSessionId = agentState?.sessionId || recentEvents.find((event) => event.sessionId)?.sessionId || '';
+  return { recentEvents, agentState, linkedSessionId };
 }
 
 export function drilldownHtml(alert, context) {
-  const { recentEvents, agentState } = context;
+  const { recentEvents, agentState, linkedSessionId } = context;
 
   const agentSection = agentState
     ? `<div class="drilldown-section">
@@ -38,6 +47,16 @@ export function drilldownHtml(alert, context) {
           <span>Model: <strong>${escapeHtml(agentState.model || '-')}</strong></span>
           <span>Tokens: <strong>${agentState.tokenTotal ?? 0}</strong></span>
           <span>Events: ${agentState.total ?? 0} (ok: ${agentState.ok ?? 0}, warn: ${agentState.warning ?? 0}, err: ${agentState.error ?? 0})</span>
+        </div>
+      </div>`
+    : '';
+
+  const sessionSection = linkedSessionId
+    ? `<div class="drilldown-section">
+        <h3>Linked Session</h3>
+        <div class="drilldown-session-link">
+          <strong>${escapeHtml(linkedSessionId)}</strong>
+          <button class="drilldown-session-open" data-session-open="${escapeHtml(linkedSessionId)}">세션 열기</button>
         </div>
       </div>`
     : '';
@@ -67,6 +86,7 @@ export function drilldownHtml(alert, context) {
       <h3>Message</h3>
       <p>${escapeHtml(alert.message)}</p>
     </div>
+    ${sessionSection}
     ${agentSection}
     <div class="drilldown-section">
       <h3>Recent Events (${escapeHtml(alert.agentId)})</h3>
@@ -74,7 +94,8 @@ export function drilldownHtml(alert, context) {
     </div>`;
 }
 
-export function renderAlerts(alerts, el, drilldownEl, snapshot) {
+export function renderAlerts(alerts, el, drilldownEl, snapshot, options = {}) {
+  const { onOpenSession } = options;
   if (!alerts || !alerts.length) {
     el.innerHTML = '<div class="event">No active alerts</div>';
     if (drilldownEl) drilldownEl.setAttribute('hidden', '');
@@ -88,7 +109,9 @@ export function renderAlerts(alerts, el, drilldownEl, snapshot) {
     if (drilldownEl) drilldownEl.setAttribute('hidden', '');
   }
 
-  el.innerHTML = alerts.map((a) => alertItemHtml(a, a.id === _selectedAlertId)).join('');
+  el.innerHTML = alerts
+    .map((alert) => alertItemHtml(alert, alert.id === _selectedAlertId, resolveAlertSessionId(alert, snapshot)))
+    .join('');
 
   // Update drilldown if open
   if (_selectedAlertId && drilldownEl) {
@@ -126,10 +149,20 @@ export function renderAlerts(alerts, el, drilldownEl, snapshot) {
       drilldownEl.innerHTML = drilldownHtml(alert, ctx);
       drilldownEl.removeAttribute('hidden');
     }
+
+    const linkedSessionId = item.dataset.sessionId || resolveAlertSessionId(alert, snapshot);
+    if (linkedSessionId && typeof onOpenSession === 'function') {
+      onOpenSession(linkedSessionId);
+    }
   };
 
   if (drilldownEl) {
     drilldownEl.onclick = (event) => {
+      const openBtn = event.target.closest('[data-session-open]');
+      if (openBtn && typeof onOpenSession === 'function') {
+        onOpenSession(openBtn.dataset.sessionOpen);
+        return;
+      }
       if (event.target.closest('[data-drilldown-close]')) {
         _selectedAlertId = null;
         drilldownEl.setAttribute('hidden', '');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1078,6 +1078,30 @@ tr.tree-last .tree-branch::before {
   font-size: 13px;
 }
 
+.drilldown-session-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.drilldown-session-open {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--warm-text);
+  cursor: pointer;
+  padding: 4px 10px;
+  font-size: 13px;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.drilldown-session-open:hover {
+  background: var(--hover-overlay);
+  border-color: var(--warm);
+}
+
 .drilldown-event {
   display: grid;
   grid-template-columns: auto auto 1fr auto;


### PR DESCRIPTION
## Summary
- resolve alerts to sessions through agent state or recent events and expose the link in the drilldown
- open the matching session detail from the alert list and from the drilldown CTA
- add alert renderer tests for session resolution and click-through behavior

## Testing
- npm run check
- npm run test:js

Closes #123