### PR TITLE
feat: prioritize risky sessions in workspace

### DIFF
--- a/public/__tests__/sessions.test.js
+++ b/public/__tests__/sessions.test.js
@@ -1,19 +1,166 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getSessionExportAttrs, renderSessionsList, renderSessionDetail, renderSessionDetailMeta } from '../lib/renders/sessions.js';
+import {
+  getSessionExportAttrs,
+  renderSessionsList,
+  renderSessionDetail,
+  renderSessionDetailMeta,
+  selectSessionsForList
+} from '../lib/renders/sessions.js';
 
 function makeRoot() {
   return { innerHTML: '', dataset: {}, onclick: null };
 }
 
 const baseSessions = [
-  { sessionId: 's1', lastSeen: '2025-01-01T00:00:10Z', tokenTotal: 500, costUsd: 0.05, agentIds: ['a1'], sessionState: 'active' },
-  { sessionId: 's2', lastSeen: '2025-01-01T00:00:20Z', tokenTotal: 1000, costUsd: 0.10, agentIds: ['a1', 'a2'], sessionState: 'completed' }
+  {
+    sessionId: 's1',
+    lastSeen: '2025-01-01T00:00:10Z',
+    tokenTotal: 500,
+    costUsd: 0.05,
+    agentIds: ['a1'],
+    sessionState: 'active',
+    needsAttention: false,
+    needsAttentionRank: 0,
+    needsAttentionReasons: []
+  },
+  {
+    sessionId: 's2',
+    lastSeen: '2025-01-01T00:00:20Z',
+    tokenTotal: 1000,
+    costUsd: 0.1,
+    agentIds: ['a1', 'a2'],
+    sessionState: 'completed',
+    needsAttention: true,
+    needsAttentionRank: 300,
+    needsAttentionReasons: ['stuck']
+  }
 ];
+
+describe('selectSessionsForList', () => {
+  it('sorts sessions by risk, recency, cost, then token total', () => {
+    const sessions = [
+      {
+        sessionId: 'idle-most-recent',
+        lastSeen: '2025-01-01T00:00:50Z',
+        costUsd: 1.5,
+        tokenTotal: 5000,
+        needsAttentionRank: 0,
+        needsAttention: false,
+        sessionState: 'idle',
+        agentIds: []
+      },
+      {
+        sessionId: 'higher-cost',
+        lastSeen: '2025-01-01T00:00:20Z',
+        costUsd: 0.6,
+        tokenTotal: 50,
+        needsAttentionRank: 300,
+        needsAttention: true,
+        sessionState: 'active',
+        agentIds: []
+      },
+      {
+        sessionId: 'same-cost-more-tokens',
+        lastSeen: '2025-01-01T00:00:20Z',
+        costUsd: 0.4,
+        tokenTotal: 900,
+        needsAttentionRank: 300,
+        needsAttention: true,
+        sessionState: 'active',
+        agentIds: []
+      },
+      {
+        sessionId: 'same-cost-fewer-tokens',
+        lastSeen: '2025-01-01T00:00:20Z',
+        costUsd: 0.4,
+        tokenTotal: 200,
+        needsAttentionRank: 300,
+        needsAttention: true,
+        sessionState: 'active',
+        agentIds: []
+      },
+      {
+        sessionId: 'recent-warning',
+        lastSeen: '2025-01-01T00:00:30Z',
+        costUsd: 0.05,
+        tokenTotal: 100,
+        needsAttentionRank: 300,
+        needsAttention: true,
+        sessionState: 'active',
+        agentIds: []
+      },
+      {
+        sessionId: 'critical',
+        lastSeen: '2025-01-01T00:00:00Z',
+        costUsd: 0.01,
+        tokenTotal: 10,
+        needsAttentionRank: 500,
+        needsAttention: true,
+        sessionState: 'failed',
+        agentIds: []
+      }
+    ];
+
+    const result = selectSessionsForList(sessions);
+
+    assert.deepEqual(
+      result.map((session) => session.sessionId),
+      ['critical', 'recent-warning', 'higher-cost', 'same-cost-more-tokens', 'same-cost-fewer-tokens', 'idle-most-recent']
+    );
+  });
+
+  it('filters sessions by quick filter and search query', () => {
+    const sessions = [
+      {
+        sessionId: 'alpha-risk',
+        lastSeen: '2025-01-01T00:00:10Z',
+        costUsd: 0.7,
+        tokenTotal: 25000,
+        needsAttentionRank: 100,
+        needsAttention: true,
+        needsAttentionReasons: ['cost_spike'],
+        sessionState: 'active',
+        agentIds: ['writer-1']
+      },
+      {
+        sessionId: 'beta-done',
+        lastSeen: '2025-01-01T00:00:20Z',
+        costUsd: 0.1,
+        tokenTotal: 1000,
+        needsAttentionRank: 0,
+        needsAttention: false,
+        needsAttentionReasons: [],
+        sessionState: 'completed',
+        agentIds: ['reviewer-2']
+      }
+    ];
+
+    assert.deepEqual(
+      selectSessionsForList(sessions, { quickFilter: 'needs-attention' }).map((session) => session.sessionId),
+      ['alpha-risk']
+    );
+    assert.deepEqual(
+      selectSessionsForList(sessions, { quickFilter: 'completed' }).map((session) => session.sessionId),
+      ['beta-done']
+    );
+    assert.deepEqual(
+      selectSessionsForList(sessions, { query: 'WRITER-1' }).map((session) => session.sessionId),
+      ['alpha-risk']
+    );
+    assert.deepEqual(
+      selectSessionsForList(sessions, { query: 'cost_spike' }).map((session) => session.sessionId),
+      ['alpha-risk']
+    );
+  });
+});
 
 describe('renderSessionsList', () => {
   let root;
-  beforeEach(() => { root = makeRoot(); });
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
 
   it('renders session items for each session', () => {
     renderSessionsList(baseSessions, root, () => {});
@@ -31,10 +178,15 @@ describe('renderSessionsList', () => {
     assert.ok(root.innerHTML.includes('~/.claude/projects/'));
   });
 
+  it('shows filtered-empty copy when sessions exist but no rows match', () => {
+    renderSessionsList([], root, () => {}, { sourceCount: 2 });
+    assert.ok(root.innerHTML.includes('조건에 맞는 세션이 없습니다'));
+  });
+
   it('includes session cost and token info', () => {
     renderSessionsList(baseSessions, root, () => {});
     assert.ok(root.innerHTML.includes('500'));
-    assert.ok(root.innerHTML.includes('0.05'));
+    assert.ok(root.innerHTML.includes('0.0500'));
   });
 
   it('includes session state badge', () => {
@@ -47,11 +199,32 @@ describe('renderSessionsList', () => {
     renderSessionsList(baseSessions, root, () => {}, { selectedSessionId: 's2' });
     assert.ok(root.innerHTML.includes('session-item--selected'));
   });
+
+  it('keeps click-through wired to the selected session id', () => {
+    let selectedSessionId = '';
+    renderSessionsList(baseSessions, root, (sessionId) => {
+      selectedSessionId = sessionId;
+    });
+
+    root.onclick({
+      target: {
+        closest(selector) {
+          assert.equal(selector, '.session-item[data-session-id]');
+          return { dataset: { sessionId: 's2' } };
+        }
+      }
+    });
+
+    assert.equal(selectedSessionId, 's2');
+  });
 });
 
 describe('renderSessionDetail', () => {
   let root;
-  beforeEach(() => { root = makeRoot(); });
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
 
   it('renders event list', () => {
     const events = [
@@ -70,7 +243,10 @@ describe('renderSessionDetail', () => {
 
 describe('renderSessionDetailMeta', () => {
   let root;
-  beforeEach(() => { root = makeRoot(); });
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
 
   it('renders empty workspace guidance when no session is selected', () => {
     renderSessionDetailMeta(null, root);

--- a/public/app.js
+++ b/public/app.js
@@ -17,7 +17,8 @@ import {
   renderSessionDetail,
   renderSessionDetailMeta,
   fetchSessionEvents,
-  getSessionExportAttrs
+  getSessionExportAttrs,
+  selectSessionsForList
 } from './lib/renders/sessions.js';
 import { isEmptySnapshot, renderEmptyState } from './lib/empty-state.js';
 
@@ -45,6 +46,9 @@ const sessionDetailTitle = document.getElementById('sessionDetailTitle');
 const sessionDetailMeta = document.getElementById('sessionDetailMeta');
 const sessionDetailExport = document.getElementById('sessionDetailExport');
 const sessionDetailEvents = document.getElementById('sessionDetailEvents');
+const sessionQuickFilter = document.getElementById('sessionQuickFilter');
+const sessionSearch = document.getElementById('sessionSearch');
+const sessionMetaEl = document.getElementById('sessionMeta');
 
 const chartEls = {
   throughputChart: document.getElementById('throughputChart'),
@@ -67,7 +71,8 @@ let snapshotState = null;
 let renderQueued = false;
 const RANGE_KEY = 'agent_monitor_range_v1';
 let currentRange = localStorage.getItem(RANGE_KEY) || '1h';
-const storageKey = 'agent_monitor_event_filters_v1';
+const EVENT_FILTERS_KEY = 'agent_monitor_event_filters_v1';
+const SESSION_FILTERS_KEY = 'agent_monitor_session_filters_v1';
 const WORKFLOW_TOGGLE_KEY = 'agent_monitor_workflow_toggle_v1';
 let showCompleted = loadToggle(WORKFLOW_TOGGLE_KEY);
 let selectedSessionId = '';
@@ -125,8 +130,39 @@ function renderWorkflow(rows = []) {
   workflowCompletedRoot.innerHTML = completed.map((row) => renderWorkflowItem(row, now)).join('');
 }
 
-function getFilters() {
+function getEventFilters() {
   return { status: eventStatusFilter.value, limit: Number(eventLimit.value) || 50, query: eventSearch.value };
+}
+
+function getSessionFilters() {
+  return { quickFilter: sessionQuickFilter.value, query: sessionSearch.value };
+}
+
+function getVisibleSessionRows(sessionRows = []) {
+  return selectSessionsForList(sessionRows, getSessionFilters());
+}
+
+function renderSessionMeta(totalCount, visibleCount) {
+  if (totalCount === 0) {
+    sessionMetaEl.hidden = true;
+    sessionMetaEl.textContent = '';
+    return;
+  }
+
+  const filters = getSessionFilters();
+  const hasFilters = filters.quickFilter !== 'all' || filters.query.trim().length > 0;
+  sessionMetaEl.hidden = false;
+  sessionMetaEl.textContent = hasFilters ? `${visibleCount} / ${totalCount} sessions` : `${totalCount} sessions`;
+}
+
+function renderSessionListPanel(sessionRows = []) {
+  const visibleRows = getVisibleSessionRows(sessionRows);
+  renderSessionMeta(sessionRows.length, visibleRows.length);
+  renderSessionsList(visibleRows, sessionsListRoot, openSessionDetail, {
+    selectedSessionId,
+    sourceCount: sessionRows.length
+  });
+  return visibleRows;
 }
 
 function renderSnapshot(snapshot) {
@@ -137,7 +173,8 @@ function renderSnapshot(snapshot) {
     if (empty) renderEmptyState(emptyStateEl);
   }
   const sessionRows = annotateSessionsWithState(snapshot.sessions || [], snapshot.agents || []);
-  const selectedSession = resolveSelectedSession(sessionRows);
+  const visibleSessionRows = getVisibleSessionRows(sessionRows);
+  const selectedSession = resolveSelectedSession(sessionRows, visibleSessionRows);
   renderCards(snapshot.totals, sessionRows, snapshot.hourlyBuckets || [], snapshot.startedAt || '');
   renderNeedsAttention(sessionRows, needsAttentionRoot, openSessionDetail);
   populateAgentFilter(snapshot.agents || [], agentFilter);
@@ -146,11 +183,11 @@ function renderSnapshot(snapshot) {
   const allEvents = snapshot.recent || [];
   renderGraphs(allEvents, chartEls, numberFmt, snapshot.toolCallStats);
   renderTimeline(allEvents, timelineRoot, timelineTooltip, agentFilter.value);
-  const filteredEvents = getFilteredEvents(allEvents, getFilters());
+  const filteredEvents = getFilteredEvents(allEvents, getEventFilters());
   renderEvents(filteredEvents, eventsRoot);
   renderEventMeta(allEvents.length, filteredEvents.length, eventMetaEl);
   renderAlerts(snapshot.alerts || [], alertsRoot, alertDrilldownRoot, snapshot, { onOpenSession: openSessionDetail });
-  renderSessionsList(sessionRows, sessionsListRoot, openSessionDetail, { selectedSessionId });
+  renderSessionListPanel(sessionRows);
   if (selectedSession && !sessionEventsCache.has(selectedSession.sessionId) && sessionDetailState.sessionId !== selectedSession.sessionId) {
     openSessionDetail(selectedSession.sessionId);
   }
@@ -158,13 +195,14 @@ function renderSnapshot(snapshot) {
   clock.textContent = `마지막 갱신 ${new Date(snapshot.generatedAt).toLocaleTimeString()}`;
 }
 
-function resolveSelectedSession(sessionRows = []) {
+function resolveSelectedSession(sessionRows = [], visibleSessionRows = sessionRows) {
   const hasSelected = selectedSessionId && sessionRows.some((row) => row.sessionId === selectedSessionId);
   if (hasSelected) {
     return sessionRows.find((row) => row.sessionId === selectedSessionId) || null;
   }
-  selectedSessionId = sessionRows[0]?.sessionId || '';
-  return sessionRows[0] || null;
+  const fallback = visibleSessionRows[0] || null;
+  selectedSessionId = fallback?.sessionId || '';
+  return fallback;
 }
 
 function renderSelectedSessionDetail(session) {
@@ -198,23 +236,42 @@ function renderSelectedSessionDetail(session) {
 }
 
 function doSaveFilters() {
-  saveFilters(storageKey, { status: eventStatusFilter.value, limit: eventLimit.value, search: eventSearch.value });
+  saveFilters(EVENT_FILTERS_KEY, { status: eventStatusFilter.value, limit: eventLimit.value, search: eventSearch.value });
+}
+
+function doSaveSessionFilters() {
+  saveFilters(SESSION_FILTERS_KEY, { quickFilter: sessionQuickFilter.value, query: sessionSearch.value });
 }
 
 function applyLoadedFilters() {
-  const filters = loadFilters(storageKey);
+  const filters = loadFilters(EVENT_FILTERS_KEY);
   if (!filters) return;
   if (filters.status) eventStatusFilter.value = filters.status;
   if (filters.limit) eventLimit.value = filters.limit;
   if (typeof filters.search === 'string') eventSearch.value = filters.search;
 }
 
+function applyLoadedSessionFilters() {
+  const filters = loadFilters(SESSION_FILTERS_KEY);
+  if (!filters) return;
+  if (filters.quickFilter) {
+    sessionQuickFilter.value = filters.quickFilter;
+    if (!sessionQuickFilter.value) sessionQuickFilter.value = 'all';
+  }
+  if (typeof filters.query === 'string') sessionSearch.value = filters.query;
+}
+
 function refilterEvents() {
   if (!snapshotState) return;
   const allEvents = snapshotState.recent || [];
-  const filtered = getFilteredEvents(allEvents, getFilters());
+  const filtered = getFilteredEvents(allEvents, getEventFilters());
   renderEvents(filtered, eventsRoot);
   renderEventMeta(allEvents.length, filtered.length, eventMetaEl);
+}
+
+function refilterSessions() {
+  if (!snapshotState) return;
+  queueRender();
 }
 
 function openSessionDetail(sessionId) {
@@ -279,12 +336,15 @@ for (const el of [eventStatusFilter, eventLimit]) {
 }
 
 eventSearch.addEventListener('input', () => { doSaveFilters(); refilterEvents(); });
+sessionQuickFilter.addEventListener('change', () => { doSaveSessionFilters(); refilterSessions(); });
+sessionSearch.addEventListener('input', () => { doSaveSessionFilters(); refilterSessions(); });
 
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
   if (snapshotState) renderGraphs(snapshotState.recent || [], chartEls, numberFmt, snapshotState.toolCallStats);
 });
 
 applyLoadedFilters();
+applyLoadedSessionFilters();
 
 for (const b of timeRangeBar.querySelectorAll('.range-btn')) {
   b.classList.toggle('active', b.dataset.range === currentRange);
@@ -310,4 +370,5 @@ setInterval(() => {
   renderCards(snapshotState.totals, intervalSessionRows, snapshotState.hourlyBuckets || [], snapshotState.startedAt || '');
   renderWorkflow(snapshotState.workflowProgress || recalcWorkflow(snapshotState.agents));
   renderAgents(snapshotState.agents || [], agentsBody, agentFilter.value);
+  renderSessionListPanel(intervalSessionRows);
 }, 1000);

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,17 @@
           <h2>Sessions Workspace</h2>
           <small>세션 선택과 상세 진단을 먼저 수행하는 작업면</small>
         </div>
+        <div id="sessionControls" class="panel-head panel-head--sessions">
+          <label for="sessionQuickFilter">필터</label>
+          <select id="sessionQuickFilter">
+            <option value="all">all</option>
+            <option value="needs-attention">needs attention</option>
+            <option value="active">active</option>
+            <option value="completed">completed</option>
+          </select>
+          <input id="sessionSearch" type="search" placeholder="session/agent/state 검색" />
+        </div>
+        <small id="sessionMeta" class="session-meta" hidden></small>
         <div class="session-workspace">
           <div id="sessionsList" class="sessions-list"></div>
           <div id="sessionDetail" class="session-detail">

--- a/public/lib/renders/sessions.js
+++ b/public/lib/renders/sessions.js
@@ -7,6 +7,35 @@ const REASON_LABELS = {
   cost_spike: '비용 급증'
 };
 
+const SESSION_QUICK_FILTERS = new Set(['all', 'needs-attention', 'active', 'completed']);
+
+function safeNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function safeTimestamp(value) {
+  const parsed = new Date(value || '').getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeQuickFilter(value) {
+  return SESSION_QUICK_FILTERS.has(value) ? value : 'all';
+}
+
+function sessionSearchText(session = {}) {
+  return [
+    session.sessionId,
+    session.displayName,
+    session.sessionState,
+    ...(Array.isArray(session.agentIds) ? session.agentIds : []),
+    ...(Array.isArray(session.needsAttentionReasons) ? session.needsAttentionReasons : [])
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
 function sessionReasonBadges(session = {}) {
   const reasons = Array.isArray(session.needsAttentionReasons) ? session.needsAttentionReasons : [];
   if (!reasons.length) return '';
@@ -16,20 +45,68 @@ function sessionReasonBadges(session = {}) {
 }
 
 function sessionMetaHtml(session = {}) {
-  return `<span>tokens: ${Number(session.tokenTotal || 0)}</span>
-    <span>cost: $${Number(session.costUsd || 0).toFixed(4)}</span>
+  return `<span>tokens: ${safeNumber(session.tokenTotal)}</span>
+    <span>cost: $${safeNumber(session.costUsd).toFixed(4)}</span>
     <span>agents: ${Array.isArray(session.agentIds) ? session.agentIds.length : 0}</span>
     <span>last: ${relativeTime(session.lastSeen)}</span>`;
 }
 
+export function normalizeSessionListFilters(filters = {}) {
+  return {
+    query: String(filters.query ?? '').trim().toLowerCase(),
+    quickFilter: normalizeQuickFilter(filters.quickFilter)
+  };
+}
+
+export function compareSessionsByPriority(a = {}, b = {}) {
+  const rankDelta = safeNumber(b.needsAttentionRank) - safeNumber(a.needsAttentionRank);
+  if (rankDelta !== 0) return rankDelta;
+
+  const lastSeenDelta = safeTimestamp(b.lastSeen) - safeTimestamp(a.lastSeen);
+  if (lastSeenDelta !== 0) return lastSeenDelta;
+
+  const costDelta = safeNumber(b.costUsd) - safeNumber(a.costUsd);
+  if (costDelta !== 0) return costDelta;
+
+  const tokenDelta = safeNumber(b.tokenTotal) - safeNumber(a.tokenTotal);
+  if (tokenDelta !== 0) return tokenDelta;
+
+  return String(a.sessionId || '').localeCompare(String(b.sessionId || ''));
+}
+
+export function matchesSessionFilters(session = {}, filters = {}) {
+  const { query, quickFilter } = normalizeSessionListFilters(filters);
+  const needsAttention = typeof session.needsAttention === 'boolean'
+    ? session.needsAttention
+    : safeNumber(session.needsAttentionRank) > 0;
+
+  if (quickFilter === 'needs-attention' && !needsAttention) return false;
+  if (quickFilter === 'active' && session.sessionState !== 'active') return false;
+  if (quickFilter === 'completed' && session.sessionState !== 'completed') return false;
+  if (query && !sessionSearchText(session).includes(query)) return false;
+  return true;
+}
+
+export function selectSessionsForList(sessions = [], filters = {}) {
+  return sessions.filter((session) => matchesSessionFilters(session, filters)).sort(compareSessionsByPriority);
+}
+
+function renderSessionsEmptyState(root, sourceCount = 0) {
+  root.innerHTML = sourceCount > 0
+    ? '<p class="sessions-empty">조건에 맞는 세션이 없습니다. 검색어나 필터를 조정해 보세요.</p>'
+    : `<p class="sessions-empty">아직 세션이 없습니다. Claude Code를 실행하면 세션이 여기에 표시됩니다.<br><small>수집 경로: <code>~/.claude/projects/</code></small></p>`;
+  root.onclick = null;
+}
+
 export function renderSessionsList(sessions, root, onSelect, options = {}) {
-  const { selectedSessionId = '' } = options;
-  if (!sessions || sessions.length === 0) {
-    root.innerHTML = `<p class="sessions-empty">아직 세션이 없습니다. Claude Code를 실행하면 세션이 여기에 표시됩니다.<br><small>수집 경로: <code>~/.claude/projects/</code></small></p>`;
+  const rows = Array.isArray(sessions) ? sessions : [];
+  const { selectedSessionId = '', sourceCount = rows.length } = options;
+  if (rows.length === 0) {
+    renderSessionsEmptyState(root, sourceCount);
     return;
   }
 
-  root.innerHTML = sessions
+  root.innerHTML = rows
     .map(
       (s) => `<div class="session-item${s.sessionId === selectedSessionId ? ' session-item--selected' : ''}" data-session-id="${escapeHtml(s.sessionId)}">
         <div class="session-item-main">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1169,6 +1169,23 @@ tr.tree-last .tree-branch::before {
   align-items: start;
 }
 
+.panel-head--sessions {
+  margin-top: 10px;
+  justify-content: flex-start;
+}
+
+.panel-head--sessions input {
+  min-width: 220px;
+  flex: 1 1 220px;
+}
+
+.session-meta {
+  display: block;
+  margin: 6px 0 10px;
+  font-size: 12px;
+  color: var(--chart-sublabel);
+}
+
 .sessions-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add risk-first session sorting plus quick filters and search in the sessions workspace
- persist session filter state locally and surface filtered result counts
- cover sorting, filtering, filtered-empty, and click-through behavior in session tests

## Testing
- npm run check
- npm run test:js

Closes #127