### PR TITLE
feat: surface derived alerts for stuck and failed sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Claude Code 세션의 실시간 모니터링 대시보드. Rust 백엔드 + Elec
 - 토큰 지표: 총 토큰(`totals.tokenTotal`) + 에이전트별 토큰(`agents[].tokenTotal`)
 - 비용 지표: 총 비용(`totals.costTotalUsd`) 소수점 4자리 표시
 - Alerts 패널에서 경고 횟수, 비용 spike, 토큰 spike 임계값을 로컬 기준으로 조정 가능하며 저장된 값은 브라우저 `localStorage`에서 기본값을 덮어씁니다.
-- Alerts 패널은 raw warning/error와 별도로 세션 단위 `cost spike` 파생 alert도 함께 보여줍니다.
+- Alerts 패널은 raw warning/error와 별도로 세션 단위 `failed`, `stuck`, `cost spike` 파생 alert도 함께 보여줍니다.
 
 ## 실행
 

--- a/public/__tests__/derived-alerts.test.js
+++ b/public/__tests__/derived-alerts.test.js
@@ -4,6 +4,47 @@ import { annotateSessionsWithState } from '../lib/session-status.js';
 import { buildDerivedSessionAlerts, mergeAlertsForPanel } from '../lib/derived-alerts.js';
 
 describe('buildDerivedSessionAlerts', () => {
+  it('surfaces stuck and failed session state reasons as derived alerts', () => {
+    const alerts = buildDerivedSessionAlerts([
+      {
+        sessionId: 'sess-failed',
+        lastSeen: '2026-01-01T00:00:20Z',
+        error: 2,
+        needsAttentionReasons: ['failed']
+      },
+      {
+        sessionId: 'sess-stuck',
+        lastSeen: '2026-01-01T00:00:10Z',
+        needsAttentionReasons: ['stuck', 'warning']
+      }
+    ], { generatedAt: '2026-01-01T00:00:30Z' });
+
+    assert.deepEqual(alerts, [
+      {
+        id: 'derived:failed:sess-failed',
+        source: 'derived-session',
+        severity: 'error',
+        event: 'SessionFailed',
+        message: 'Session entered failed state (2 errors)',
+        createdAt: '2026-01-01T00:00:20Z',
+        sessionId: 'sess-failed',
+        agentId: '',
+        derivedReason: 'failed'
+      },
+      {
+        id: 'derived:stuck:sess-stuck',
+        source: 'derived-session',
+        severity: 'warning',
+        event: 'SessionStuck',
+        message: 'No session activity for 2m+ without a terminal event',
+        createdAt: '2026-01-01T00:00:10Z',
+        sessionId: 'sess-stuck',
+        agentId: '',
+        derivedReason: 'stuck'
+      }
+    ]);
+  });
+
   it('surfaces custom-rule cost spikes from annotated session rows', () => {
     const sessions = [{
       sessionId: 'sess-risk',
@@ -42,12 +83,12 @@ describe('buildDerivedSessionAlerts', () => {
     });
   });
 
-  it('ignores session reasons that are already represented elsewhere', () => {
+  it('ignores session reasons without a derived alert builder', () => {
     const alerts = buildDerivedSessionAlerts([
       {
         sessionId: 'sess-stuck',
         lastSeen: '2026-01-01T00:00:00Z',
-        needsAttentionReasons: ['stuck', 'warning']
+        needsAttentionReasons: ['warning']
       }
     ]);
 
@@ -65,19 +106,26 @@ describe('mergeAlertsForPanel', () => {
       message: 'boom',
       createdAt: '2026-01-01T00:00:10Z'
     }];
-    const sessionRows = [{
-      sessionId: 'sess-risk',
-      lastSeen: '2026-01-01T00:00:20Z',
-      costUsd: 0.6,
-      tokenTotal: 22_000,
-      needsAttentionReasons: ['cost_spike']
-    }];
+    const sessionRows = [
+      {
+        sessionId: 'sess-risk',
+        lastSeen: '2026-01-01T00:00:20Z',
+        costUsd: 0.6,
+        tokenTotal: 22_000,
+        needsAttentionReasons: ['cost_spike']
+      },
+      {
+        sessionId: 'sess-stuck',
+        lastSeen: '2026-01-01T00:00:08Z',
+        needsAttentionReasons: ['stuck']
+      }
+    ];
 
     const merged = mergeAlertsForPanel(rawAlerts, sessionRows, {
       generatedAt: '2026-01-01T00:00:30Z'
     });
 
-    assert.deepEqual(merged.map((alert) => alert.id), ['derived:cost_spike:sess-risk', 'raw-1']);
+    assert.deepEqual(merged.map((alert) => alert.id), ['derived:cost_spike:sess-risk', 'raw-1', 'derived:stuck:sess-stuck']);
     assert.equal(merged[1], rawAlerts[0]);
   });
 

--- a/public/lib/derived-alerts.js
+++ b/public/lib/derived-alerts.js
@@ -1,4 +1,19 @@
 const DERIVED_ALERT_BUILDERS = {
+  failed: {
+    event: 'SessionFailed',
+    severity: 'error',
+    buildMessage(session) {
+      const errorCount = Number(session.error) || 0;
+      return `Session entered failed state (${errorCount} errors)`;
+    }
+  },
+  stuck: {
+    event: 'SessionStuck',
+    severity: 'warning',
+    buildMessage() {
+      return 'No session activity for 2m+ without a terminal event';
+    }
+  },
   cost_spike: {
     event: 'SessionCostSpike',
     severity: 'warning',


### PR DESCRIPTION
## Summary
- extend session-derived alerts beyond cost spikes
- surface `stuck` and `failed` session states in the Alerts panel
- update the README copy to match the new alert coverage

## Testing
- npm run check
- npm run test:js

Closes #149