### PR TITLE
feat: show session participants and linked alerts

### DIFF
--- a/public/__tests__/alerts.test.js
+++ b/public/__tests__/alerts.test.js
@@ -6,7 +6,8 @@ import {
   drilldownHtml,
   renderAlerts,
   resolveAlertSessionId,
-  resetAlertSelection
+  resetAlertSelection,
+  selectAlertById
 } from '../lib/renders/alerts.js';
 
 function makeAlert(overrides = {}) {
@@ -389,5 +390,34 @@ describe('renderAlerts', () => {
     assert.equal(openedSessionId, 'sess-derived');
     assert.equal(drilldownRoot.hidden, false);
     assert.ok(drilldownRoot.innerHTML.includes('sess-derived'));
+  });
+
+  it('preserves selected alert drilldown when selection is triggered externally', () => {
+    const alertItem = {
+      dataset: { alertId: 'alert-1' },
+      classList: { add() {}, remove() {} }
+    };
+    const alertsRoot = {
+      innerHTML: '',
+      onclick: null,
+      querySelectorAll(selector) {
+        if (selector === '[data-alert-id]') return [alertItem];
+        return [];
+      }
+    };
+    const drilldownRoot = makeDrilldownRoot();
+    const alerts = [makeAlert({ sessionId: 'sess-1' })];
+    const snapshot = makeSnapshot({
+      recent: [makeEvent({ sessionId: 'sess-1' })]
+    });
+
+    renderAlerts(alerts, alertsRoot, drilldownRoot, snapshot);
+    assert.equal(selectAlertById('alert-1', alerts, alertsRoot, drilldownRoot, snapshot), true);
+    assert.equal(drilldownRoot.hidden, false);
+    assert.ok(drilldownRoot.innerHTML.includes('sess-1'));
+
+    renderAlerts(alerts, alertsRoot, drilldownRoot, snapshot);
+    assert.equal(drilldownRoot.hidden, false);
+    assert.ok(drilldownRoot.innerHTML.includes('sess-1'));
   });
 });

--- a/public/__tests__/sessions.test.js
+++ b/public/__tests__/sessions.test.js
@@ -7,6 +7,7 @@ import {
   renderSessionDetailMeta,
   selectSessionsForList
 } from '../lib/renders/sessions.js';
+import { resetDisplayNames } from '../lib/agent-display.js';
 
 function makeRoot() {
   return { innerHTML: '', dataset: {}, onclick: null };
@@ -246,6 +247,7 @@ describe('renderSessionDetailMeta', () => {
 
   beforeEach(() => {
     root = makeRoot();
+    resetDisplayNames();
   });
 
   it('renders empty workspace guidance when no session is selected', () => {
@@ -267,6 +269,39 @@ describe('renderSessionDetailMeta', () => {
     assert.ok(root.innerHTML.includes('Attention Rank'));
     assert.ok(root.innerHTML.includes('오류 발생'));
     assert.ok(root.innerHTML.includes('data-status="failed"'));
+  });
+
+  it('renders session participants and linked alerts in the detail summary', () => {
+    renderSessionDetailMeta({
+      sessionId: 's1',
+      sessionState: 'active',
+      lastSeen: '2025-01-01T00:00:10Z',
+      tokenTotal: 500,
+      costUsd: 0.05,
+      agentIds: ['lead-1', 'sub-2'],
+      needsAttentionRank: 100,
+      needsAttentionReasons: ['cost_spike']
+    }, root, {
+      sessionAgents: [
+        { agentId: 'lead-1', model: 'claude-opus-4-6' },
+        { agentId: 'sub-2', model: 'claude-sonnet-4-6' }
+      ],
+      sessionAlerts: [
+        {
+          id: 'derived:stuck:s1',
+          severity: 'warning',
+          event: 'SessionStuck',
+          message: 'No session activity for 2m+ without a terminal event'
+        }
+      ]
+    });
+
+    assert.ok(root.innerHTML.includes('Participants'));
+    assert.ok(root.innerHTML.includes('Lead (Opus)'));
+    assert.ok(root.innerHTML.includes('Sub (Sonnet)'));
+    assert.ok(root.innerHTML.includes('Linked Alerts'));
+    assert.ok(root.innerHTML.includes('data-session-alert-id="derived:stuck:s1"'));
+    assert.ok(root.innerHTML.includes('SessionStuck'));
   });
 });
 

--- a/public/app.js
+++ b/public/app.js
@@ -13,7 +13,7 @@ import { renderAlertRules } from './lib/renders/alert-rules.js';
 import { renderGraphs } from './lib/renders/charts.js';
 import { getFilteredEvents, renderEventMeta, renderEvents } from './lib/renders/events.js';
 import { renderAgents, populateAgentFilter, toggleAgentTreeNode } from './lib/renders/agents.js';
-import { renderAlerts } from './lib/renders/alerts.js';
+import { renderAlerts, resolveAlertSessionId, selectAlertById } from './lib/renders/alerts.js';
 import { renderTimeline } from './lib/renders/timeline.js';
 import {
   renderSessionsList,
@@ -83,6 +83,8 @@ let selectedSessionId = '';
 const sessionEventsCache = new Map();
 let sessionDetailState = { sessionId: '', loading: false, error: false };
 let alertRules = loadAlertRules(ALERT_RULES_STORAGE_KEY);
+let currentPanelAlerts = [];
+let currentAlertSnapshot = null;
 
 function queueRender() {
   if (renderQueued) return;
@@ -182,6 +184,8 @@ function renderSnapshot(snapshot) {
   const selectedSession = resolveSelectedSession(sessionRows, visibleSessionRows);
   const alerts = mergeAlertsForPanel(snapshot.alerts || [], sessionRows, { generatedAt: snapshot.generatedAt });
   const alertSnapshot = { ...snapshot, sessions: sessionRows };
+  currentPanelAlerts = alerts;
+  currentAlertSnapshot = alertSnapshot;
   renderCards(snapshot.totals, sessionRows, snapshot.hourlyBuckets || [], snapshot.startedAt || '');
   renderNeedsAttention(sessionRows, needsAttentionRoot, openSessionDetail);
   populateAgentFilter(snapshot.agents || [], agentFilter);
@@ -214,8 +218,14 @@ function resolveSelectedSession(sessionRows = [], visibleSessionRows = sessionRo
 
 function renderSelectedSessionDetail(session) {
   sessionDetailTitle.textContent = session?.sessionId || '선택된 세션 없음';
-  renderSessionDetailMeta(session, sessionDetailMeta);
   const hasSession = Boolean(session?.sessionId);
+  const sessionAgents = hasSession
+    ? (snapshotState?.agents || []).filter((agent) => agent.sessionId === session.sessionId)
+    : [];
+  const sessionAlerts = hasSession
+    ? currentPanelAlerts.filter((alert) => resolveAlertSessionId(alert, currentAlertSnapshot) === session.sessionId)
+    : [];
+  renderSessionDetailMeta(session, sessionDetailMeta, { sessionAgents, sessionAlerts });
   sessionDetailBack.hidden = !hasSession;
   sessionDetailExport.hidden = !hasSession;
   if (!hasSession) {
@@ -240,6 +250,11 @@ function renderSelectedSessionDetail(session) {
   }
 
   renderSessionDetail(sessionEventsCache.get(session.sessionId) || [], sessionDetailEvents);
+}
+
+function openAlertFromSessionDetail(alertId) {
+  if (!alertId || !currentAlertSnapshot) return;
+  selectAlertById(alertId, currentPanelAlerts, alertsRoot, alertDrilldownRoot, currentAlertSnapshot);
 }
 
 function doSaveFilters() {
@@ -320,6 +335,12 @@ sessionDetailBack.addEventListener('click', () => {
   selectedSessionId = '';
   sessionDetailState = { sessionId: '', loading: false, error: false };
   queueRender();
+});
+
+sessionDetailMeta.addEventListener('click', (event) => {
+  const alertBtn = event.target.closest('[data-session-alert-id]');
+  if (!alertBtn) return;
+  openAlertFromSessionDetail(alertBtn.dataset.sessionAlertId);
 });
 
 workflowToggle.addEventListener('click', () => {

--- a/public/lib/renders/alerts.js
+++ b/public/lib/renders/alerts.js
@@ -117,6 +117,35 @@ export function drilldownHtml(alert, context) {
     </div>`;
 }
 
+function clearSelectedAlertClasses(el) {
+  if (!el?.querySelectorAll) return;
+  el.querySelectorAll('.alert-item--selected').forEach((item) => item.classList.remove('alert-item--selected'));
+}
+
+export function selectAlertById(alertId, alerts = [], el, drilldownEl, snapshot) {
+  const alert = alerts.find((entry) => entry.id === alertId);
+  if (!alert) return false;
+
+  _selectedAlertId = alertId;
+  clearSelectedAlertClasses(el);
+
+  if (el?.querySelectorAll) {
+    el.querySelectorAll('[data-alert-id]').forEach((item) => {
+      if (item.dataset?.alertId === alertId) {
+        item.classList.add('alert-item--selected');
+      }
+    });
+  }
+
+  if (drilldownEl) {
+    const ctx = getAlertContext(alert, snapshot);
+    drilldownEl.innerHTML = drilldownHtml(alert, ctx);
+    drilldownEl.removeAttribute('hidden');
+  }
+
+  return true;
+}
+
 export function renderAlerts(alerts, el, drilldownEl, snapshot, options = {}) {
   const { onOpenSession } = options;
   if (!alerts || !alerts.length) {
@@ -138,12 +167,7 @@ export function renderAlerts(alerts, el, drilldownEl, snapshot, options = {}) {
 
   // Update drilldown if open
   if (_selectedAlertId && drilldownEl) {
-    const selected = alerts.find((a) => a.id === _selectedAlertId);
-    if (selected) {
-      const ctx = getAlertContext(selected, snapshot);
-      drilldownEl.innerHTML = drilldownHtml(selected, ctx);
-      drilldownEl.removeAttribute('hidden');
-    }
+    selectAlertById(_selectedAlertId, alerts, el, drilldownEl, snapshot);
   }
 
   el.onclick = (event) => {
@@ -162,16 +186,7 @@ export function renderAlerts(alerts, el, drilldownEl, snapshot, options = {}) {
       return;
     }
 
-    // Deselect previous
-    el.querySelectorAll('.alert-item--selected').forEach((prev) => prev.classList.remove('alert-item--selected'));
-    _selectedAlertId = alertId;
-    item.classList.add('alert-item--selected');
-
-    if (drilldownEl) {
-      const ctx = getAlertContext(alert, snapshot);
-      drilldownEl.innerHTML = drilldownHtml(alert, ctx);
-      drilldownEl.removeAttribute('hidden');
-    }
+    selectAlertById(alertId, alerts, el, drilldownEl, snapshot);
 
     const linkedSessionId = item.dataset.sessionId || resolveAlertSessionId(alert, snapshot);
     if (linkedSessionId && typeof onOpenSession === 'function') {

--- a/public/lib/renders/sessions.js
+++ b/public/lib/renders/sessions.js
@@ -1,4 +1,5 @@
 import { escapeHtml, relativeTime, statusPill } from '../utils.js';
+import { displayNameFor } from '../agent-display.js';
 
 const REASON_LABELS = {
   failed: '오류 발생',
@@ -155,7 +156,47 @@ function summaryStat(label, value) {
   </div>`;
 }
 
-export function renderSessionDetailMeta(session, root) {
+function renderSessionParticipants(session = {}, sessionAgents = []) {
+  const participants = sessionAgents.length
+    ? sessionAgents.map((agent) => ({
+        agentId: agent.agentId,
+        label: displayNameFor(agent.agentId, agent.model || '')
+      }))
+    : (Array.isArray(session.agentIds) ? session.agentIds : []).map((agentId) => ({
+        agentId,
+        label: displayNameFor(agentId)
+      }));
+
+  if (!participants.length) {
+    return '<p class="session-detail-note">참여 agent 정보가 아직 없습니다.</p>';
+  }
+
+  return `<div class="session-detail-chip-list">${participants
+    .map(
+      (agent) => `<span class="session-detail-chip" title="${escapeHtml(agent.agentId)}">${escapeHtml(agent.label)}</span>`
+    )
+    .join('')}</div>`;
+}
+
+function renderSessionAlerts(sessionAlerts = []) {
+  if (!sessionAlerts.length) {
+    return '<p class="session-detail-note">연결된 alert가 없습니다.</p>';
+  }
+
+  return `<div class="session-detail-alert-list">${sessionAlerts
+    .map(
+      (alert) => `<button type="button" class="session-detail-alert-item" data-session-alert-id="${escapeHtml(alert.id)}">
+        ${statusPill(alert.severity || 'warning')}
+        <span class="session-detail-alert-text">
+          <strong>${escapeHtml(alert.event || 'Alert')}</strong>
+          <span>${escapeHtml(alert.message || '')}</span>
+        </span>
+      </button>`
+    )
+    .join('')}</div>`;
+}
+
+export function renderSessionDetailMeta(session, root, options = {}) {
   if (!session) {
     root.innerHTML = `<div class="session-detail-empty">
       <strong>세션을 선택하세요</strong>
@@ -164,6 +205,7 @@ export function renderSessionDetailMeta(session, root) {
     return;
   }
 
+  const { sessionAgents = [], sessionAlerts = [] } = options;
   const reasonBadges = sessionReasonBadges(session);
   root.innerHTML = `
     <div class="session-detail-summary">
@@ -177,6 +219,14 @@ export function renderSessionDetailMeta(session, root) {
         ${summaryStat('Cost', `$${Number(session.costUsd || 0).toFixed(4)}`)}
         ${summaryStat('Agents', String(Array.isArray(session.agentIds) ? session.agentIds.length : 0))}
         ${summaryStat('Attention Rank', String(Number(session.needsAttentionRank || 0)))}
+      </div>
+      <div class="session-detail-section">
+        <h3>Participants</h3>
+        ${renderSessionParticipants(session, sessionAgents)}
+      </div>
+      <div class="session-detail-section">
+        <h3>Linked Alerts</h3>
+        ${renderSessionAlerts(sessionAlerts)}
       </div>
     </div>`;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1377,6 +1377,16 @@ tr.tree-last .tree-branch::before {
   gap: 8px;
 }
 
+.session-detail-section {
+  display: grid;
+  gap: 8px;
+}
+
+.session-detail-section h3 {
+  margin: 0;
+  font-size: 13px;
+}
+
 .session-detail-stat {
   padding: 10px;
   border: 1px solid var(--border-subtle);
@@ -1395,6 +1405,63 @@ tr.tree-last .tree-branch::before {
   margin-top: 4px;
   font-size: 14px;
   font-weight: 600;
+}
+
+.session-detail-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.session-detail-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--surface);
+  font-size: 12px;
+}
+
+.session-detail-note {
+  margin: 0;
+  color: var(--chart-sublabel);
+  font-size: 13px;
+}
+
+.session-detail-alert-list {
+  display: grid;
+  gap: 8px;
+}
+
+.session-detail-alert-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-detail-alert-item:hover {
+  background: var(--hover-overlay);
+}
+
+.session-detail-alert-text {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.session-detail-alert-text strong,
+.session-detail-alert-text span {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .session-detail-empty {


### PR DESCRIPTION
## Summary
- show participating agents directly in the session detail summary
- surface linked alerts inside the Sessions Workspace detail panel
- reuse the existing alert drilldown state so detail-triggered alerts stay open across rerenders

## Testing
- npm run check
- npm run test:js

Closes #150