### PR TITLE
refactor(ui): 주요 세션 화면에서 raw session ID를 displayName으로 교체

### DIFF
--- a/public/__tests__/needs-attention.test.js
+++ b/public/__tests__/needs-attention.test.js
@@ -94,6 +94,26 @@ describe('renderNeedsAttention', () => {
     assert.ok(root.innerHTML.includes('cost: $0.7500'));
   });
 
+  it('renders displayName as the primary label when provided', () => {
+    renderNeedsAttention([
+      {
+        sessionId: 'sess-uuid-1234',
+        displayName: '로그인 버그 수정',
+        sessionState: 'stuck',
+        needsAttention: true,
+        needsAttentionRank: 300,
+        needsAttentionReasons: ['stuck'],
+        lastSeen: '2025-01-01T00:00:00Z',
+        tokenTotal: 100,
+        costUsd: 0.01,
+        agentIds: []
+      }
+    ], root, () => {});
+
+    assert.ok(root.innerHTML.includes('로그인 버그 수정'));
+    assert.ok(!root.innerHTML.includes('>sess-uuid-1234<'));
+  });
+
   it('wires row click back to the existing session detail handler', () => {
     let selected = '';
     renderNeedsAttention([{ sessionId: 'sess-2', sessionState: 'failed' }], root, (sessionId) => {

--- a/public/__tests__/sessions.test.js
+++ b/public/__tests__/sessions.test.js
@@ -163,6 +163,41 @@ describe('renderSessionsList', () => {
     root = makeRoot();
   });
 
+  it('renders displayName as the primary label instead of raw sessionId', () => {
+    const sessions = [
+      { ...baseSessions[0], displayName: '로그인 버그 수정', projectName: 'my-project', shortSessionId: 's1short' }
+    ];
+    renderSessionsList(sessions, root, () => {});
+    assert.ok(root.innerHTML.includes('로그인 버그 수정'));
+    assert.ok(root.innerHTML.includes('session-item-name'));
+    assert.ok(!root.innerHTML.includes('session-item-id'));
+  });
+
+  it('falls back to shortSessionId when displayName is empty', () => {
+    const sessions = [
+      { ...baseSessions[0], displayName: '', shortSessionId: 'abcd1234' }
+    ];
+    renderSessionsList(sessions, root, () => {});
+    assert.ok(root.innerHTML.includes('abcd1234'));
+  });
+
+  it('falls back to sessionId when both displayName and shortSessionId are empty', () => {
+    const sessions = [
+      { ...baseSessions[0], displayName: '', shortSessionId: '' }
+    ];
+    renderSessionsList(sessions, root, () => {});
+    assert.ok(root.innerHTML.includes('s1'));
+  });
+
+  it('renders secondary label with project name, state, and last activity', () => {
+    const sessions = [
+      { ...baseSessions[0], displayName: '버그 수정', projectName: 'claude-monitor' }
+    ];
+    renderSessionsList(sessions, root, () => {});
+    assert.ok(root.innerHTML.includes('session-item-secondary'));
+    assert.ok(root.innerHTML.includes('claude-monitor'));
+  });
+
   it('renders session items for each session', () => {
     renderSessionsList(baseSessions, root, () => {});
     assert.ok(root.innerHTML.includes('s1'));
@@ -269,6 +304,21 @@ describe('renderSessionDetailMeta', () => {
     assert.ok(root.innerHTML.includes('Attention Rank'));
     assert.ok(root.innerHTML.includes('오류 발생'));
     assert.ok(root.innerHTML.includes('data-status="failed"'));
+  });
+
+  it('renders full session_id as copyable meta info in the detail summary', () => {
+    renderSessionDetailMeta({
+      sessionId: 'fdab33ec-c234-4fe5-a84d-f35eee9af6f4',
+      sessionState: 'active',
+      lastSeen: '2025-01-01T00:00:10Z',
+      tokenTotal: 500,
+      costUsd: 0.05,
+      agentIds: ['a1'],
+      needsAttentionRank: 0,
+      needsAttentionReasons: []
+    }, root);
+    assert.ok(root.innerHTML.includes('fdab33ec-c234-4fe5-a84d-f35eee9af6f4'));
+    assert.ok(root.innerHTML.includes('session-detail-session-id'));
   });
 
   it('renders session participants and linked alerts in the detail summary', () => {

--- a/public/app.js
+++ b/public/app.js
@@ -245,7 +245,7 @@ function renderSnapshot(snapshot) {
 }
 
 function renderSelectedSessionDetail(session) {
-  sessionDetailTitle.textContent = session?.sessionId || '선택된 세션 없음';
+  sessionDetailTitle.textContent = session?.displayName || session?.sessionId || '선택된 세션 없음';
   const hasSession = Boolean(session?.sessionId);
   const sessionAgents = hasSession
     ? (snapshotState?.agents || []).filter((agent) => agent.sessionId === session.sessionId)

--- a/public/lib/renders/sessions.js
+++ b/public/lib/renders/sessions.js
@@ -2,6 +2,15 @@ import { escapeHtml, relativeTime, statusPill } from '../utils.js';
 import { displayNameFor } from '../agent-display.js';
 import { sanitizeAlertRules } from '../alert-rules.js';
 
+function sessionDisplayLabel(session = {}) {
+  return session.displayName || session.shortSessionId || session.sessionId || '';
+}
+
+function sessionSecondaryHtml(session = {}) {
+  const parts = [session.projectName, session.sessionState || 'idle', relativeTime(session.lastSeen)].filter(Boolean);
+  return `<div class="session-item-secondary">${parts.map(escapeHtml).join(' · ')}</div>`;
+}
+
 const REASON_LABELS = {
   failed: '오류 발생',
   stuck: '응답 지연',
@@ -112,9 +121,10 @@ export function renderSessionsList(sessions, root, onSelect, options = {}) {
     .map(
       (s) => `<div class="session-item${s.sessionId === selectedSessionId ? ' session-item--selected' : ''}" data-session-id="${escapeHtml(s.sessionId)}">
         <div class="session-item-main">
-          <div class="session-item-id">${escapeHtml(s.sessionId)}</div>
+          <div class="session-item-name">${escapeHtml(sessionDisplayLabel(s))}</div>
           ${statusPill(s.sessionState || 'idle')}
         </div>
+        ${sessionSecondaryHtml(s)}
         <div class="session-item-meta">
           ${sessionMetaHtml(s)}
         </div>
@@ -220,6 +230,10 @@ export function renderSessionDetailMeta(session, root, options = {}) {
         ${summaryStat('Cost', `$${Number(session.costUsd || 0).toFixed(4)}`)}
         ${summaryStat('Agents', String(Array.isArray(session.agentIds) ? session.agentIds.length : 0))}
         ${summaryStat('Attention Rank', String(Number(session.needsAttentionRank || 0)))}
+      </div>
+      <div class="session-detail-section">
+        <h3>Session ID</h3>
+        <span class="session-detail-session-id" title="${escapeHtml(session.sessionId)}">${escapeHtml(session.sessionId)}</span>
       </div>
       <div class="session-detail-section">
         <h3>Participants</h3>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1302,13 +1302,21 @@ tr.tree-last .tree-branch::before {
   gap: 12px;
 }
 
-.session-item-id {
+.session-item-name {
   font-weight: 600;
   font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 260px;
+}
+
+.session-item-secondary {
+  font-size: 12px;
+  color: var(--chart-sublabel);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .session-item-meta {
@@ -1427,6 +1435,15 @@ tr.tree-last .tree-branch::before {
   margin: 0;
   color: var(--chart-sublabel);
   font-size: 13px;
+}
+
+.session-detail-session-id {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--chart-sublabel);
+  word-break: break-all;
+  user-select: all;
+  cursor: text;
 }
 
 .session-detail-alert-list {


### PR DESCRIPTION
## Summary
- Sessions List 1행을 `displayName` 중심으로 변경하고, `projectName · state · lastSeen` 보조 라벨 행 추가
- Session Detail 상단 제목을 `displayName`으로 교체, full `session_id`는 메타 영역에 복사 가능한 형태로 노출
- `app.js`의 Detail 제목 렌더링을 `displayName || sessionId` fallback 방식으로 변경

## Changes
- `public/lib/renders/sessions.js`: `sessionDisplayLabel` 헬퍼 추가, 리스트 1행 교체, 보조 라벨 행 추가, Detail 메타에 Session ID 섹션 추가
- `public/app.js`: `renderSelectedSessionDetail` 제목 필드 `displayName` 우선으로 변경
- `public/styles.css`: `.session-item-id` → `.session-item-name`, `.session-item-secondary`, `.session-detail-session-id` 스타일 추가
- `public/__tests__/sessions.test.js`: displayName 렌더링·fallback·보조 라벨·session_id 메타 테스트 4건 추가
- `public/__tests__/needs-attention.test.js`: displayName 우선 표시 테스트 1건 추가

## Related Issue
Closes #158

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)