### PR TITLE
feat(ui): displayName 검색 확장 및 중복 세션 구분 기능 추가

### DIFF
--- a/public/__tests__/needs-attention.test.js
+++ b/public/__tests__/needs-attention.test.js
@@ -114,6 +114,74 @@ describe('renderNeedsAttention', () => {
     assert.ok(!root.innerHTML.includes('>sess-uuid-1234<'));
   });
 
+  it('shows shortSessionId when duplicate displayNames exist', () => {
+    renderNeedsAttention([
+      {
+        sessionId: 'sess-uuid-1',
+        displayName: '버그 수정',
+        shortSessionId: 'abcd1234',
+        sessionState: 'failed',
+        needsAttention: true,
+        needsAttentionRank: 400,
+        needsAttentionReasons: ['failed'],
+        lastSeen: '2025-01-01T00:00:00Z',
+        tokenTotal: 100,
+        costUsd: 0.01,
+        agentIds: []
+      },
+      {
+        sessionId: 'sess-uuid-2',
+        displayName: '버그 수정',
+        shortSessionId: 'efgh5678',
+        sessionState: 'stuck',
+        needsAttention: true,
+        needsAttentionRank: 300,
+        needsAttentionReasons: ['stuck'],
+        lastSeen: '2025-01-01T00:00:00Z',
+        tokenTotal: 200,
+        costUsd: 0.02,
+        agentIds: []
+      }
+    ], root, () => {});
+
+    assert.ok(root.innerHTML.includes('abcd1234'));
+    assert.ok(root.innerHTML.includes('efgh5678'));
+  });
+
+  it('does not show shortSessionId when displayNames are unique', () => {
+    renderNeedsAttention([
+      {
+        sessionId: 'sess-uuid-1',
+        displayName: '로그인 에러',
+        shortSessionId: 'abcd1234',
+        sessionState: 'failed',
+        needsAttention: true,
+        needsAttentionRank: 400,
+        needsAttentionReasons: ['failed'],
+        lastSeen: '2025-01-01T00:00:00Z',
+        tokenTotal: 100,
+        costUsd: 0.01,
+        agentIds: []
+      },
+      {
+        sessionId: 'sess-uuid-2',
+        displayName: '빌드 실패',
+        shortSessionId: 'efgh5678',
+        sessionState: 'stuck',
+        needsAttention: true,
+        needsAttentionRank: 300,
+        needsAttentionReasons: ['stuck'],
+        lastSeen: '2025-01-01T00:00:00Z',
+        tokenTotal: 200,
+        costUsd: 0.02,
+        agentIds: []
+      }
+    ], root, () => {});
+
+    assert.ok(!root.innerHTML.includes('abcd1234'));
+    assert.ok(!root.innerHTML.includes('efgh5678'));
+  });
+
   it('wires row click back to the existing session detail handler', () => {
     let selected = '';
     renderNeedsAttention([{ sessionId: 'sess-2', sessionState: 'failed' }], root, (sessionId) => {

--- a/public/__tests__/sessions.test.js
+++ b/public/__tests__/sessions.test.js
@@ -154,6 +154,63 @@ describe('selectSessionsForList', () => {
       ['alpha-risk']
     );
   });
+
+  it('searches by projectName, shortSessionId, and full sessionId', () => {
+    const sessions = [
+      {
+        sessionId: 'fdab33ec-c234-4fe5-a84d-f35eee9af6f4',
+        displayName: '로그인 버그 수정',
+        projectName: 'billing-api',
+        shortSessionId: 'fdab33ec',
+        lastSeen: '2025-01-01T00:00:10Z',
+        costUsd: 0.1,
+        tokenTotal: 500,
+        needsAttentionRank: 0,
+        needsAttention: false,
+        needsAttentionReasons: [],
+        sessionState: 'active',
+        agentIds: []
+      },
+      {
+        sessionId: 'aaaa1111-bbbb-cccc-dddd-eeeeffffaaaa',
+        displayName: '다크모드 추가',
+        projectName: 'frontend-app',
+        shortSessionId: 'aaaa1111',
+        lastSeen: '2025-01-01T00:00:20Z',
+        costUsd: 0.2,
+        tokenTotal: 1000,
+        needsAttentionRank: 0,
+        needsAttention: false,
+        needsAttentionReasons: [],
+        sessionState: 'active',
+        agentIds: []
+      }
+    ];
+
+    // search by projectName
+    assert.deepEqual(
+      selectSessionsForList(sessions, { query: 'billing-api' }).map((s) => s.sessionId),
+      ['fdab33ec-c234-4fe5-a84d-f35eee9af6f4']
+    );
+
+    // search by shortSessionId
+    assert.deepEqual(
+      selectSessionsForList(sessions, { query: 'aaaa1111' }).map((s) => s.sessionId),
+      ['aaaa1111-bbbb-cccc-dddd-eeeeffffaaaa']
+    );
+
+    // search by full sessionId
+    assert.deepEqual(
+      selectSessionsForList(sessions, { query: 'fdab33ec-c234' }).map((s) => s.sessionId),
+      ['fdab33ec-c234-4fe5-a84d-f35eee9af6f4']
+    );
+
+    // search by displayName
+    assert.deepEqual(
+      selectSessionsForList(sessions, { query: '로그인' }).map((s) => s.sessionId),
+      ['fdab33ec-c234-4fe5-a84d-f35eee9af6f4']
+    );
+  });
 });
 
 describe('renderSessionsList', () => {
@@ -187,6 +244,26 @@ describe('renderSessionsList', () => {
     ];
     renderSessionsList(sessions, root, () => {});
     assert.ok(root.innerHTML.includes('s1'));
+  });
+
+  it('shows shortSessionId in secondary label when displayNames collide', () => {
+    const sessions = [
+      { ...baseSessions[0], sessionId: 's1-uuid', displayName: '버그 수정', projectName: 'my-project', shortSessionId: 'abcd1234' },
+      { ...baseSessions[1], sessionId: 's2-uuid', displayName: '버그 수정', projectName: 'my-project', shortSessionId: 'efgh5678' }
+    ];
+    renderSessionsList(sessions, root, () => {});
+    assert.ok(root.innerHTML.includes('abcd1234'));
+    assert.ok(root.innerHTML.includes('efgh5678'));
+  });
+
+  it('does not show shortSessionId when displayNames are unique', () => {
+    const sessions = [
+      { ...baseSessions[0], sessionId: 's1-uuid', displayName: '로그인 수정', projectName: 'my-project', shortSessionId: 'abcd1234' },
+      { ...baseSessions[1], sessionId: 's2-uuid', displayName: '다크모드 추가', projectName: 'my-project', shortSessionId: 'efgh5678' }
+    ];
+    renderSessionsList(sessions, root, () => {});
+    assert.ok(!root.innerHTML.includes('abcd1234'));
+    assert.ok(!root.innerHTML.includes('efgh5678'));
   });
 
   it('renders secondary label with project name, state, and last activity', () => {

--- a/public/__tests__/utils.test.js
+++ b/public/__tests__/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { escapeHtml, statusPill, normalizeText, getActivityStatus, activityDotHtml, countActiveAgents, relativeTime } from '../lib/utils.js';
+import { escapeHtml, statusPill, normalizeText, getActivityStatus, activityDotHtml, countActiveAgents, relativeTime, countDuplicateLabels } from '../lib/utils.js';
 
 describe('escapeHtml', () => {
   it('escapes & < > " \'', () => {
@@ -196,5 +196,24 @@ describe('relativeTime', () => {
 
   it('returns "-" for invalid date string', () => {
     assert.equal(relativeTime('not-a-date'), '-');
+  });
+});
+
+describe('countDuplicateLabels', () => {
+  it('counts occurrences of each label', () => {
+    const items = ['버그 수정', '다크모드', '버그 수정'];
+    const counts = countDuplicateLabels(items);
+    assert.equal(counts.get('버그 수정'), 2);
+    assert.equal(counts.get('다크모드'), 1);
+  });
+
+  it('returns empty map for empty array', () => {
+    const counts = countDuplicateLabels([]);
+    assert.equal(counts.size, 0);
+  });
+
+  it('handles single item', () => {
+    const counts = countDuplicateLabels(['only-one']);
+    assert.equal(counts.get('only-one'), 1);
   });
 });

--- a/public/lib/needs-attention.js
+++ b/public/lib/needs-attention.js
@@ -1,4 +1,4 @@
-import { escapeHtml, relativeTime, statusPill } from './utils.js';
+import { escapeHtml, relativeTime, statusPill, countDuplicateLabels } from './utils.js';
 
 const REASON_ORDER = ['failed', 'stuck', 'warning', 'cost_spike'];
 
@@ -90,13 +90,20 @@ export function renderNeedsAttention(sessions, root, onSelect) {
     return;
   }
 
+  const nameCounts = countDuplicateLabels(rows.map((s) => s.displayName || s.sessionId));
+
   root.innerHTML = rows
     .map(
-      (session) => `<button type="button" class="attention-item" data-session-id="${escapeHtml(session.sessionId)}">
+      (session) => {
+        const label = session.displayName || session.sessionId;
+        const disambig = (nameCounts.get(label) || 0) > 1 && session.shortSessionId
+          ? ` <span class="attention-item-short-id">${escapeHtml(session.shortSessionId)}</span>`
+          : '';
+        return `<button type="button" class="attention-item" data-session-id="${escapeHtml(session.sessionId)}">
         <div class="attention-item-main">
           <div class="attention-item-title">
             <div class="attention-item-head">
-              <strong class="attention-item-id">${escapeHtml(session.displayName || session.sessionId)}</strong>
+              <strong class="attention-item-id">${escapeHtml(label)}</strong>${disambig}
               ${statusPill(session.sessionState)}
             </div>
             <div class="attention-reasons">
@@ -111,7 +118,8 @@ export function renderNeedsAttention(sessions, root, onSelect) {
           <span>cost: $${Number(session.costUsd || 0).toFixed(4)}</span>
           <span>agents: ${Array.isArray(session.agentIds) ? session.agentIds.length : 0}</span>
         </div>
-      </button>`
+      </button>`;
+      }
     )
     .join('');
 

--- a/public/lib/renders/sessions.js
+++ b/public/lib/renders/sessions.js
@@ -1,4 +1,4 @@
-import { escapeHtml, relativeTime, statusPill } from '../utils.js';
+import { escapeHtml, relativeTime, statusPill, countDuplicateLabels } from '../utils.js';
 import { displayNameFor } from '../agent-display.js';
 import { sanitizeAlertRules } from '../alert-rules.js';
 
@@ -6,8 +6,11 @@ function sessionDisplayLabel(session = {}) {
   return session.displayName || session.shortSessionId || session.sessionId || '';
 }
 
-function sessionSecondaryHtml(session = {}) {
+function sessionSecondaryHtml(session = {}, options = {}) {
   const parts = [session.projectName, session.sessionState || 'idle', relativeTime(session.lastSeen)].filter(Boolean);
+  if (options.showShortId && session.shortSessionId) {
+    parts.push(session.shortSessionId);
+  }
   return `<div class="session-item-secondary">${parts.map(escapeHtml).join(' · ')}</div>`;
 }
 
@@ -38,6 +41,8 @@ function sessionSearchText(session = {}) {
   return [
     session.sessionId,
     session.displayName,
+    session.projectName,
+    session.shortSessionId,
     session.sessionState,
     ...(Array.isArray(session.agentIds) ? session.agentIds : []),
     ...(Array.isArray(session.needsAttentionReasons) ? session.needsAttentionReasons : [])
@@ -117,19 +122,25 @@ export function renderSessionsList(sessions, root, onSelect, options = {}) {
     return;
   }
 
+  const nameCounts = countDuplicateLabels(rows.map(sessionDisplayLabel));
+
   root.innerHTML = rows
     .map(
-      (s) => `<div class="session-item${s.sessionId === selectedSessionId ? ' session-item--selected' : ''}" data-session-id="${escapeHtml(s.sessionId)}">
+      (s) => {
+        const label = sessionDisplayLabel(s);
+        const showShortId = (nameCounts.get(label) || 0) > 1;
+        return `<div class="session-item${s.sessionId === selectedSessionId ? ' session-item--selected' : ''}" data-session-id="${escapeHtml(s.sessionId)}">
         <div class="session-item-main">
-          <div class="session-item-name">${escapeHtml(sessionDisplayLabel(s))}</div>
+          <div class="session-item-name">${escapeHtml(label)}</div>
           ${statusPill(s.sessionState || 'idle')}
         </div>
-        ${sessionSecondaryHtml(s)}
+        ${sessionSecondaryHtml(s, { showShortId })}
         <div class="session-item-meta">
           ${sessionMetaHtml(s)}
         </div>
         ${sessionReasonBadges(s)}
-      </div>`
+      </div>`;
+      }
     )
     .join('');
 

--- a/public/lib/utils.js
+++ b/public/lib/utils.js
@@ -45,6 +45,14 @@ export function relativeTime(isoString, now = Date.now()) {
   return `${Math.floor(elapsed / 86400)}일 전`;
 }
 
+export function countDuplicateLabels(labels) {
+  const counts = new Map();
+  for (const label of labels) {
+    counts.set(label, (counts.get(label) || 0) + 1);
+  }
+  return counts;
+}
+
 export function countActiveAgents(agents, now = Date.now()) {
   return agents.filter((a) => now - new Date(a.lastSeen).getTime() < 30_000).length;
 }


### PR DESCRIPTION
## Summary
- 세션 검색이 `displayName`, `projectName`, `shortSessionId`, full `sessionId`를 모두 찾도록 확장
- 동일 `displayName`을 가진 세션이 여럿일 때 secondary label에 `shortSessionId`를 표시하여 구분
- 중복 감지 로직을 `countDuplicateLabels` 공통 유틸로 추출

## Changes
- `public/lib/renders/sessions.js`: `sessionSearchText()`에 `projectName`, `shortSessionId` 추가, 중복 displayName 감지 시 secondary label에 shortSessionId 표시
- `public/lib/needs-attention.js`: needs-attention 뷰에서도 중복 displayName 시 shortSessionId 보조 표시
- `public/lib/utils.js`: `countDuplicateLabels()` 유틸 함수 추가
- `public/__tests__/sessions.test.js`: 검색 확장 테스트, 중복 구분 테스트 추가
- `public/__tests__/needs-attention.test.js`: 중복 구분 테스트 추가
- `public/__tests__/utils.test.js`: `countDuplicateLabels` 단위 테스트 추가

## Related Issue
Closes #159

## Test Plan
- [ ] `cargo fmt --check` pass
- [ ] `cargo clippy -- -D warnings` pass
- [ ] `cargo test` pass
- [ ] `npm run check` pass
- [ ] Manual verification of related functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)